### PR TITLE
Bedrock class

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,6 @@ All documentation can also be found in the web server's footer `Docs` link.
 
 ### Platform Differences:
 - Windows suppport has the following limitations such as:
- - send-command requires seperate start method (no yet available)
  - No attach to console support
  - No service integration
 

--- a/src/bedrock_server_manager/__init__.py
+++ b/src/bedrock_server_manager/__init__.py
@@ -329,6 +329,7 @@ def main() -> None:
             "-m",
             "--mode",
             choices=["direct", "detached"],
+            default="detached",
             help="Mode to start server in",
         )
 

--- a/src/bedrock_server_manager/__init__.py
+++ b/src/bedrock_server_manager/__init__.py
@@ -325,6 +325,13 @@ def main() -> None:
             "start-server", help="Start a server"
         )
         add_server_arg(start_server_parser)
+        start_server_parser.add_argument(
+            "-m",
+            "--mode",
+            choices=["direct", "detached"],
+            help="Mode to start server in",
+        )
+
         stop_server_parser = subparsers.add_parser("stop-server", help="Stop a server")
         add_server_arg(stop_server_parser)
         restart_parser = subparsers.add_parser(
@@ -744,7 +751,9 @@ def main() -> None:
             "update-server": lambda args: cli_server_install_config.update_server(
                 args.server, base_dir
             ),
-            "start-server": lambda args: cli_server.start_server(args.server, base_dir),
+            "start-server": lambda args: cli_server.start_server(
+                args.server, base_dir, args.mode
+            ),
             "stop-server": lambda args: cli_server.stop_server(args.server, base_dir),
             "install-world": lambda args: (
                 cli_world.import_world_cli(

--- a/src/bedrock_server_manager/api/addon.py
+++ b/src/bedrock_server_manager/api/addon.py
@@ -13,16 +13,17 @@ from typing import Dict, Optional
 # Local imports
 from bedrock_server_manager.core.server import addon as core_addon
 from bedrock_server_manager.utils.general import get_base_dir
-from bedrock_server_manager.core.system import base as system_base
 from bedrock_server_manager.error import (
     MissingArgumentError,
     FileOperationError,
     FileNotFoundError,
+    InvalidAddonPackTypeError,
+    AddonExtractError,
+    DirectoryError,
+    InvalidServerNameError,
+    RestoreError,
 )
-from bedrock_server_manager.api.server import (
-    start_server,
-    stop_server,
-)
+from bedrock_server_manager.api.utils import _server_stop_start_manager
 
 logger = logging.getLogger("bedrock_server_manager")
 
@@ -32,168 +33,88 @@ def import_addon(
     addon_file_path: str,
     base_dir: Optional[str] = None,
     stop_start_server: bool = True,
+    restart_only_on_success: bool = True,
 ) -> Dict[str, str]:
     """
     Installs an addon (.mcaddon or .mcpack) to the specified server.
 
-    Handles finding the server directory, optionally stopping the server before
-    installation and restarting it afterwards, processing the addon file using
-    core functions, and returning a status dictionary.
-
     Args:
         server_name: The name of the target server.
         addon_file_path: The full path to the addon file to install.
-        base_dir: Optional. The base directory containing server installations.
-                  If None, uses the configured default.
-        stop_start_server: If True (default), attempts to stop the server before
-                           installing and restart it afterwards if it was initially running.
+        base_dir: Optional. Base directory for server installations.
+        stop_start_server: If True, attempts to stop/start server around addon processing.
+        restart_only_on_success: If stop_start_server is True, only restart if addon
+                                 processing itself was successful.
 
     Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "message": "Addon installed successfully."} on success.
-        - {"status": "error", "message": "Error description..."} on failure.
-
-    Raises:
-        MissingArgumentError: If `server_name` or `addon_file_path` is empty.
-        FileNotFoundError: If `addon_file_path` does not point to an existing file.
-        FileOperationError: If `base_dir` cannot be determined (e.g., setting missing).
-        # Underlying exceptions from server stop/start/addon processing are caught
-        # and converted into the error dictionary return format.
+        A dictionary indicating the outcome.
     """
     addon_filename = os.path.basename(addon_file_path) if addon_file_path else "N/A"
     logger.info(
-        f"Initiating addon import process for server '{server_name}' from file '{addon_filename}'."
+        f"API: Initiating addon import for '{server_name}' from '{addon_filename}'. "
+        f"Stop/Start: {stop_start_server}, RestartOnSuccess: {restart_only_on_success}"
     )
 
-    # --- Input Validation ---
     if not server_name:
-        # Raise immediately for invalid input
         raise MissingArgumentError("Server name cannot be empty.")
     if not addon_file_path:
         raise MissingArgumentError("Addon file path cannot be empty.")
     if not os.path.isfile(addon_file_path):
-        # Check if it's specifically a file, not just exists
-        error_msg = f"Addon file does not exist or is not a file: {addon_file_path}"
-        logger.error(error_msg)
-        raise FileNotFoundError(error_msg)
+        raise FileNotFoundError(f"Addon file not found: {addon_file_path}")
 
     try:
-        # Determine base directory (raises FileOperationError if setting missing)
         effective_base_dir = get_base_dir(base_dir)
-        logger.debug(f"Using base directory: {effective_base_dir}")
-    except FileOperationError as e:
-        logger.error(f"Cannot proceed with addon import: {e}", exc_info=True)
-        # Convert to the return dict format for API consistency at this boundary
-        return {"status": "error", "message": f"Configuration error: {e}"}
+        logger.debug(f"API: Using base directory: {effective_base_dir}")
 
-    # --- Server Stop (Optional) ---
-    was_running = False
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking if server '{server_name}' is running before addon import..."
+        # The _server_stop_start_manager will handle stopping the server if stop_start_server is True,
+        # and restarting it in its finally block based on was_running and restart_only_on_success.
+        with _server_stop_start_manager(
+            server_name,
+            effective_base_dir,
+            stop_start_flag=stop_start_server,
+            restart_on_success_only=restart_only_on_success,
+        ):
+            logger.info(
+                f"API: Processing addon file '{addon_filename}' for server '{server_name}'..."
             )
-            # Check running status before attempting stop
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping before addon installation..."
-                )
-                stop_result = stop_server(
-                    server_name, effective_base_dir
-                )  # This function returns a dict
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' before addon import: {stop_result.get('message')}"
-                    )
-                    # Return the error from stop_server directly
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped successfully.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running. No stop needed.")
-        except Exception as e:
-            # Catch unexpected errors during check/stop
-            logger.error(
-                f"Error stopping server '{server_name}' before addon import: {e}",
-                exc_info=True,
+            # Delegate to the core addon processing function.
+            # This function will raise specific errors (AddonExtractError, FileOperationError, etc.) on failure.
+            core_addon.process_addon(addon_file_path, server_name, effective_base_dir)
+            logger.info(
+                f"API: Core addon processing completed for '{addon_filename}' on '{server_name}'."
             )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server before import: {e}",
-            }
 
-    # --- Addon Installation ---
-    install_error = None
-    try:
-        logger.info(
-            f"Processing addon file '{addon_filename}' for server '{server_name}'..."
-        )
-        # Delegate to the core addon processing function
-        core_addon.process_addon(addon_file_path, server_name, effective_base_dir)
-        logger.info(
-            f"Core addon processing completed for '{addon_filename}' on server '{server_name}'."
-        )
-        # Success is determined after potential restart below
+        # If the 'with' block completed without an exception, the main operation was successful.
+        # The context manager handles the restart if needed.
+        message = f"Addon '{addon_filename}' installed successfully for server '{server_name}'."
+        if stop_start_server:
+            message += " Server stop/start cycle handled."
+        return {"status": "success", "message": message}
 
-    except Exception as e:
-        # Catch errors from core_addon.process_addon and store them
-        install_error = e
+    # Catch specific errors that can be raised by core_addon.process_addon or the context manager
+    except (
+        MissingArgumentError,
+        FileNotFoundError,
+        FileOperationError,
+        AddonExtractError,
+        InvalidAddonPackTypeError,
+        DirectoryError,
+        InvalidServerNameError,
+        RestoreError,
+    ) as e:
         logger.error(
-            f"Core addon processing failed for '{addon_filename}' on server '{server_name}': {e}",
+            f"API: Addon import failed for '{addon_filename}' on '{server_name}': {e}",
             exc_info=True,
         )
-        # Don't return yet, proceed to finally block for potential restart
-
-    # --- Server Start (Optional, runs even if install failed) ---
-    finally:
-        restart_error = None
-        if stop_start_server and was_running:
-            if install_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though addon processing failed."
-                )
-            else:
-                logger.info(
-                    f"Restarting server '{server_name}' after addon processing..."
-                )
-
-            try:
-                start_result = start_server(
-                    server_name, effective_base_dir
-                )  # This function returns a dict
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after addon processing: {start_result.get('message')}"
-                    )
-                    restart_error = start_result  # Store the error dict
-                else:
-                    logger.info(
-                        f"Server '{server_name}' restart initiated successfully."
-                    )
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after addon processing: {e}",
-                    exc_info=True,
-                )
-                restart_error = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Determine Final Result ---
-    if install_error:
-        # If installation failed, report that error primarily
         return {
             "status": "error",
-            "message": f"Error installing addon '{addon_filename}': {install_error}",
+            "message": f"Error installing addon '{addon_filename}': {e}",
         }
-    elif restart_error:
-        # If installation succeeded but restart failed, report the restart error
-        # This indicates addon files might be present but server isn't running as expected
-        return restart_error
-    else:
-        # Installation succeeded, and restart either wasn't needed, wasn't attempted, or succeeded
-        return {
-            "status": "success",
-            "message": f"Addon '{addon_filename}' installed successfully for server '{server_name}'.",
-        }
+    except (
+        Exception
+    ) as e:  # Catch any other unexpected errors, including from _server_stop_start_manager's finally block
+        logger.error(
+            f"API: Unexpected error during addon import for '{server_name}': {e}",
+            exc_info=True,
+        )
+        return {"status": "error", "message": f"Unexpected error installing addon: {e}"}

--- a/src/bedrock_server_manager/api/backup_restore.py
+++ b/src/bedrock_server_manager/api/backup_restore.py
@@ -378,7 +378,10 @@ def restore_config_file(
             raise FileNotFoundError(f"Backup file not found: {backup_file_path}")
 
         with _server_stop_start_manager(
-            server_name, effective_base_dir, stop_start_server, restart_on_success_only=True
+            server_name,
+            effective_base_dir,
+            stop_start_server,
+            restart_on_success_only=True,
         ):
             restored_file = core_backup.restore_config_file_data(
                 backup_file_path, server_install_dir
@@ -426,7 +429,10 @@ def restore_all(
         # Core restore_all_server_data checks BACKUP_DIR
 
         with _server_stop_start_manager(
-            server_name, effective_base_dir, stop_start_server, restart_on_success_only=True
+            server_name,
+            effective_base_dir,
+            stop_start_server,
+            restart_on_success_only=True,
         ):
             results = core_backup.restore_all_server_data(
                 server_name, effective_base_dir

--- a/src/bedrock_server_manager/api/backup_restore.py
+++ b/src/bedrock_server_manager/api/backup_restore.py
@@ -378,7 +378,7 @@ def restore_config_file(
             raise FileNotFoundError(f"Backup file not found: {backup_file_path}")
 
         with _server_stop_start_manager(
-            server_name, effective_base_dir, stop_start_server
+            server_name, effective_base_dir, stop_start_server, restart_on_success_only=True
         ):
             restored_file = core_backup.restore_config_file_data(
                 backup_file_path, server_install_dir
@@ -426,7 +426,7 @@ def restore_all(
         # Core restore_all_server_data checks BACKUP_DIR
 
         with _server_stop_start_manager(
-            server_name, effective_base_dir, stop_start_server
+            server_name, effective_base_dir, stop_start_server, restart_on_success_only=True
         ):
             results = core_backup.restore_all_server_data(
                 server_name, effective_base_dir

--- a/src/bedrock_server_manager/api/backup_restore.py
+++ b/src/bedrock_server_manager/api/backup_restore.py
@@ -11,14 +11,17 @@ import os
 import logging
 import glob
 from typing import Dict, List, Optional, Any
+from contextlib import contextmanager
 
 # Local imports
 from bedrock_server_manager.core.server import backup as core_backup
+from bedrock_server_manager.core.server import world as core_world
 from bedrock_server_manager.config.settings import settings
-from bedrock_server_manager.api.world import get_world_name
+from bedrock_server_manager.api.world import get_world_name as api_get_world_name
 from bedrock_server_manager.utils.general import get_base_dir
 from bedrock_server_manager.core.system import base as system_base
-from bedrock_server_manager.api.server import start_server, stop_server
+from bedrock_server_manager.api.server import start_server as api_start_server
+from bedrock_server_manager.api.server import stop_server as api_stop_server
 from bedrock_server_manager.error import (
     MissingArgumentError,
     InvalidInputError,
@@ -29,9 +32,62 @@ from bedrock_server_manager.error import (
     RestoreError,
     DownloadExtractError,
     InvalidServerNameError,
+    AddonExtractError,
 )
 
 logger = logging.getLogger("bedrock_server_manager")
+
+
+@contextmanager
+def _server_stop_start_manager(server_name: str, base_dir: str, stop_start_flag: bool):
+    """
+    Context manager to handle stopping a server before an operation and
+    restarting it afterward if it was running.
+    """
+    was_running = False
+    error_during_operation = False
+    if not stop_start_flag:
+        yield
+        return
+
+    try:
+        logger.debug(f"Checking running status for '{server_name}' for stop/start manager...")
+        if system_base.is_server_running(server_name, base_dir):
+            was_running = True
+            logger.info(f"Server '{server_name}' is running. Stopping for operation...")
+            stop_result = api_stop_server(server_name, base_dir)
+            if stop_result.get("status") == "error":
+                # If stop fails, we cannot safely proceed with the main operation.
+                # Raise an exception that the caller API function can catch.
+                raise FileOperationError(f"Failed to stop server '{server_name}': {stop_result.get('message')}")
+            logger.info(f"Server '{server_name}' stopped for operation.")
+        else:
+            logger.debug(f"Server '{server_name}' is not running. No stop needed.")
+        
+        yield # This is where the main backup/restore operation will run
+
+    except Exception:
+        error_during_operation = True # Mark that the main operation failed
+        raise # Re-raise the exception from the main operation
+    finally:
+        if stop_start_flag and was_running:
+            if error_during_operation:
+                logger.warning(
+                    f"Attempting to restart server '{server_name}' even though the main operation failed."
+                )
+            else:
+                logger.info(f"Restarting server '{server_name}' after operation...")
+            
+            start_result = api_start_server(server_name, base_dir)
+            if start_result.get("status") == "error":
+                # Log this error, but don't overwrite an existing error from the main operation
+                logger.error(
+                    f"Failed to restart server '{server_name}' after operation: {start_result.get('message')}"
+                )
+                if not error_during_operation: # If main op was fine, this becomes the primary error
+                    raise FileOperationError(f"Operation successful, but failed to restart server: {start_result.get('message')}")
+            else:
+                logger.info(f"Server '{server_name}' restart initiated after operation.")
 
 
 def list_backup_files(server_name: str, backup_type: str) -> Dict[str, Any]:
@@ -49,6 +105,7 @@ def list_backup_files(server_name: str, backup_type: str) -> Dict[str, Any]:
 
     Raises:
         MissingArgumentError: If `server_name` or `backup_type` is empty.
+        InvalidInputError: If `backup_type` is invalid.
         FileOperationError: If BACKUP_DIR setting is missing.
     """
     if not server_name:
@@ -58,58 +115,43 @@ def list_backup_files(server_name: str, backup_type: str) -> Dict[str, Any]:
 
     backup_base_dir = settings.get("BACKUP_DIR")
     if not backup_base_dir:
-        raise FileOperationError(
-            "BACKUP_DIR setting is missing or empty in configuration."
-        )
+        raise FileOperationError("BACKUP_DIR setting is missing or empty in configuration.")
 
-    backup_dir = os.path.join(backup_base_dir, server_name)
+    server_backup_dir = os.path.join(backup_base_dir, server_name)
     backup_type_norm = backup_type.lower()
     logger.info(
-        f"Listing '{backup_type_norm}' backups for server '{server_name}' in '{backup_dir}'..."
+        f"Listing '{backup_type_norm}' backups for server '{server_name}' in '{server_backup_dir}'..."
     )
 
-    if not os.path.isdir(backup_dir):
-        logger.warning(
-            f"Backup directory not found: '{backup_dir}'. Returning empty list."
-        )
-        # Consistent with finding 0 files, return success with empty list
+    if not os.path.isdir(server_backup_dir):
+        logger.warning(f"Backup directory not found: '{server_backup_dir}'. Returning empty list.")
         return {"status": "success", "backups": []}
 
     try:
         backup_files: List[str] = []
         if backup_type_norm == "world":
-            pattern = os.path.join(backup_dir, "*.mcworld")
+            pattern = os.path.join(server_backup_dir, "*.mcworld") # Matches any .mcworld
             backup_files = glob.glob(pattern)
-            logger.debug(
-                f"Found {len(backup_files)} world backups matching pattern '{pattern}'."
-            )
         elif backup_type_norm == "config":
-            # Find JSON and properties backup files
-            json_pattern = os.path.join(backup_dir, "*_backup_*.json")
-            props_pattern = os.path.join(backup_dir, "server_backup_*.properties")
+            # Generic pattern for config files (name_backup_timestamp.ext)
+            # This will find all files matching the timestamped backup pattern for configs.
+            json_pattern = os.path.join(server_backup_dir, "*_backup_*.json")
+            props_pattern = os.path.join(server_backup_dir, "*_backup_*.properties")
             backup_files.extend(glob.glob(json_pattern))
             backup_files.extend(glob.glob(props_pattern))
-            logger.debug(f"Found {len(backup_files)} config backups matching patterns.")
         else:
-            # Raise error for invalid type passed to API function
-            raise InvalidInputError(
-                f"Invalid backup type specified: '{backup_type}'. Must be 'world' or 'config'."
-            )
+            raise InvalidInputError(f"Invalid backup type: '{backup_type}'. Must be 'world' or 'config'.")
 
-        # Sort by modification time, newest first
         backup_files.sort(key=os.path.getmtime, reverse=True)
-
         return {"status": "success", "backups": backup_files}
 
+    except InvalidInputError: # Re-raise this specific error
+        raise
     except OSError as e:
-        logger.error(
-            f"Error accessing backup directory '{backup_dir}': {e}", exc_info=True
-        )
+        logger.error(f"Error accessing backup directory '{server_backup_dir}': {e}", exc_info=True)
         return {"status": "error", "message": f"Error listing backups: {e}"}
     except Exception as e:
-        logger.error(
-            f"Unexpected error listing backups for '{server_name}': {e}", exc_info=True
-        )
+        logger.error(f"Unexpected error listing backups for '{server_name}': {e}", exc_info=True)
         return {"status": "error", "message": f"Unexpected error listing backups: {e}"}
 
 
@@ -118,321 +160,85 @@ def backup_world(
 ) -> Dict[str, str]:
     """
     Creates a backup of the server's world directory (.mcworld file).
-
-    Orchestrates optional server stop/start, finds the world path, calls the
-    core backup function, and handles errors.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. The base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop server before backup and restart after if it was running.
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
-
-    logger.info(
-        f"Initiating world backup for server '{server_name}'. Stop/Start: {stop_start_server}"
-    )
-
-    try:
-        effective_base_dir = get_base_dir(
-            base_dir
-        )  # Raises FileOperationError if setting missing
-        backup_base_dir = settings.get("BACKUP_DIR")
-        if not backup_base_dir:
-            raise FileOperationError("BACKUP_DIR setting missing.")
-
-        server_backup_dir = os.path.join(backup_base_dir, server_name)
-        os.makedirs(server_backup_dir, exist_ok=True)  # Ensure backup dir exists
-
-    except FileOperationError as e:
-        logger.error(
-            f"Configuration error preventing world backup for '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {"status": "error", "message": f"Configuration error: {e}"}
-
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before world backup..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for world backup..."
-                )
-                stop_result = stop_server(server_name, effective_base_dir)
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for backup: {stop_result.get('message')}"
-                    )
-                    return stop_result  # Return error from stop_server
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for world backup: {e}",
-                exc_info=True,
-            )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server for backup: {e}",
-            }
-
-    # --- Core Backup Operation ---
-    backup_error = None
-    try:
-        # Get world name (API function returns dict)
-        world_name_result = get_world_name(server_name, effective_base_dir)
-        if world_name_result.get("status") == "error":
-            # Propagate error if world name couldn't be found
-            raise FileOperationError(
-                world_name_result.get("message", "Could not determine world name.")
-            )
-
-        world_name = world_name_result["world_name"]
-        world_path = os.path.join(effective_base_dir, server_name, "worlds", world_name)
-
-        # Check existence before calling core backup
-        if not os.path.isdir(world_path):
-            raise DirectoryError(f"World directory does not exist: {world_path}")
-
-        # Call core backup function
-        core_backup.backup_world(world_path, server_backup_dir, world_name)
-        logger.info(f"Core world backup function completed for server '{server_name}'.")
-
-    except (
-        DirectoryError,
-        FileOperationError,
-        MissingArgumentError,
-        BackupWorldError,
-    ) as e:
-        backup_error = e
-        logger.error(
-            f"World backup failed for server '{server_name}': {e}", exc_info=True
-        )
-        # Don't return yet, proceed to finally for potential restart
-    except Exception as e:
-        backup_error = e
-        logger.error(
-            f"Unexpected error during world backup for server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if backup_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though world backup failed."
-                )
-            else:
-                logger.info(f"Restarting server '{server_name}' after world backup...")
-
-            try:
-                start_result = start_server(server_name, effective_base_dir)
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after backup: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result  # Store restart error dict
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after backup: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if backup_error:
-        return {"status": "error", "message": f"World backup failed: {backup_error}"}
-    elif restart_error_dict:
-        # Backup succeeded, but restart failed
-        return restart_error_dict
-    else:
-        return {
-            "status": "success",
-            "message": f"World backup completed successfully for server '{server_name}'.",
-        }
-
-
-def backup_config_file(
-    server_name: str,
-    file_to_backup: str,
-    base_dir: Optional[str] = None,
-    stop_start_server: bool = True,
-) -> Dict[str, str]:
-    """
-    Creates a backup of a specific configuration file from the server directory.
-
-    Args:
-        server_name: The name of the server.
-        file_to_backup: The relative path of the file within the server's directory
-                        (e.g., "server.properties", "permissions.json").
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop/start server around backup (usually not necessary).
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}.
-
-    Raises:
-        MissingArgumentError: If `server_name` or `file_to_backup` is empty.
-        FileNotFoundError: If the configuration file to back up does not exist.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing.
-    """
-    if not server_name:
-        raise MissingArgumentError("Server name cannot be empty.")
-    if not file_to_backup:
-        raise MissingArgumentError("File to backup cannot be empty.")
-
-    filename_base = os.path.basename(file_to_backup)
-    logger.info(
-        f"Initiating config file backup for '{filename_base}' on server '{server_name}'. Stop/Start: {stop_start_server}"
-    )
+    logger.info(f"API: Initiating world backup for server '{server_name}'. Stop/Start: {stop_start_server}")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
         backup_base_dir = settings.get("BACKUP_DIR")
         if not backup_base_dir:
             raise FileOperationError("BACKUP_DIR setting missing.")
+        server_backup_dir = os.path.join(backup_base_dir, server_name)
+        os.makedirs(server_backup_dir, exist_ok=True)
 
+        world_name_res = api_get_world_name(server_name, effective_base_dir) # Use API that returns dict
+        if world_name_res.get("status") == "error":
+            return world_name_res # Propagate error
+        world_name = world_name_res["world_name"]
+        world_path = os.path.join(effective_base_dir, server_name, "worlds", world_name)
+
+        if not os.path.isdir(world_path):
+            raise DirectoryError(f"World directory does not exist: {world_path}")
+
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            backup_file = core_backup.backup_world_data(world_path, server_backup_dir, world_name)
+        
+        return {
+            "status": "success",
+            "message": f"World backup '{os.path.basename(backup_file)}' created successfully for server '{server_name}'.",
+        }
+    except (MissingArgumentError, FileOperationError, DirectoryError, AddonExtractError, BackupWorldError) as e:
+        logger.error(f"API: World backup failed for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"World backup failed: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during world backup for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error during world backup: {e}"}
+
+
+def backup_config_file(
+    server_name: str,
+    file_to_backup: str, # Relative path from server dir
+    base_dir: Optional[str] = None,
+    stop_start_server: bool = True, # Usually False for single config
+) -> Dict[str, str]:
+    """
+    Creates a backup of a specific configuration file from the server directory.
+    """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty.")
+    if not file_to_backup:
+        raise MissingArgumentError("File to backup cannot be empty.")
+    
+    filename_base = os.path.basename(file_to_backup)
+    logger.info(f"API: Initiating config file backup for '{filename_base}' on server '{server_name}'. Stop/Start: {stop_start_server}")
+
+    try:
+        effective_base_dir = get_base_dir(base_dir)
+        backup_base_dir = settings.get("BACKUP_DIR")
+        if not backup_base_dir:
+            raise FileOperationError("BACKUP_DIR setting missing.")
         server_backup_dir = os.path.join(backup_base_dir, server_name)
         os.makedirs(server_backup_dir, exist_ok=True)
 
         full_file_path = os.path.join(effective_base_dir, server_name, file_to_backup)
-
-        # Check existence before stopping server
         if not os.path.isfile(full_file_path):
-            raise FileNotFoundError(
-                f"Configuration file not found at: {full_file_path}"
-            )
+            raise FileNotFoundError(f"Configuration file not found: {full_file_path}")
 
-    except (
-        FileOperationError,
-        FileNotFoundError,
-    ) as e:  # Catch config/validation errors early
-        logger.error(
-            f"Pre-backup check failed for config '{filename_base}' on server '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {
-            "status": "error",
-            "message": f"Configuration error or file not found: {e}",
-        }
-
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before config backup..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for config backup..."
-                )
-                stop_result = stop_server(server_name, effective_base_dir)
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for backup: {stop_result.get('message')}"
-                    )
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for config backup: {e}",
-                exc_info=True,
-            )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server for backup: {e}",
-            }
-
-    # --- Core Backup Operation ---
-    backup_error = None
-    try:
-        # Call core backup function
-        core_backup.backup_config_file(full_file_path, server_backup_dir)
-        logger.info(
-            f"Core config file backup function completed for '{filename_base}' on server '{server_name}'."
-        )
-    except (FileNotFoundError, FileOperationError, MissingArgumentError) as e:
-        backup_error = e
-        logger.error(
-            f"Config file backup failed for '{filename_base}' on server '{server_name}': {e}",
-            exc_info=True,
-        )
-    except Exception as e:
-        backup_error = e
-        logger.error(
-            f"Unexpected error during config file backup for '{filename_base}' on server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if backup_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though config backup failed."
-                )
-            else:
-                logger.info(f"Restarting server '{server_name}' after config backup...")
-            try:
-                start_result = start_server(server_name, effective_base_dir)
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after backup: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after backup: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if backup_error:
-        return {
-            "status": "error",
-            "message": f"Config file backup for '{filename_base}' failed: {backup_error}",
-        }
-    elif restart_error_dict:
-        return restart_error_dict
-    else:
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            backup_file = core_backup.backup_single_config_file(full_file_path, server_backup_dir)
+        
         return {
             "status": "success",
-            "message": f"Config file backup for '{filename_base}' completed successfully.",
+            "message": f"Config file '{filename_base}' backed up as '{os.path.basename(backup_file)}' successfully.",
         }
+    except (MissingArgumentError, FileOperationError, FileNotFoundError) as e:
+        logger.error(f"API: Config file backup failed for '{filename_base}' on '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Config file backup failed: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during config file backup for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error during config file backup: {e}"}
 
 
 def backup_all(
@@ -440,132 +246,36 @@ def backup_all(
 ) -> Dict[str, str]:
     """
     Performs a full backup (world and standard config files) for the specified server.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop server before backup and restart after if it was running.
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}. Will report partial success if some configs fail.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
-
-    logger.info(
-        f"Initiating full backup for server '{server_name}'. Stop/Start: {stop_start_server}"
-    )
+    logger.info(f"API: Initiating full backup for server '{server_name}'. Stop/Start: {stop_start_server}")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
-        # Check backup dir setting early
-        if not settings.get("BACKUP_DIR"):
-            raise FileOperationError("BACKUP_DIR setting missing.")
-    except FileOperationError as e:
-        logger.error(
-            f"Configuration error preventing full backup for '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {"status": "error", "message": f"Configuration error: {e}"}
+        # Core backup_all_server_data checks BACKUP_DIR setting
 
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before full backup..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for full backup..."
-                )
-                stop_result = stop_server(server_name, effective_base_dir)
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for backup: {stop_result.get('message')}"
-                    )
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for full backup: {e}",
-                exc_info=True,
-            )
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            results = core_backup.backup_all_server_data(server_name, effective_base_dir)
+        
+        failed_components = [comp for comp, path in results.items() if path is None]
+        if failed_components:
             return {
-                "status": "error",
-                "message": f"Failed to stop server for backup: {e}",
+                "status": "error", # Or "partial_success" if you want to distinguish
+                "message": f"Full backup for '{server_name}' completed with errors. Failed components: {', '.join(failed_components)}.",
+                "details": results
             }
-
-    # --- Core Backup Operation ---
-    backup_error = None
-    try:
-        # Call core backup_all function
-        core_backup.backup_all(server_name, effective_base_dir)
-        logger.info(f"Core full backup function completed for server '{server_name}'.")
-    except (BackupWorldError, FileOperationError, MissingArgumentError) as e:
-        backup_error = e
-        logger.error(
-            f"Full backup failed for server '{server_name}': {e}", exc_info=True
-        )
-    except Exception as e:
-        backup_error = e
-        logger.error(
-            f"Unexpected error during full backup for server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if backup_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though full backup failed."
-                )
-            else:
-                logger.info(f"Restarting server '{server_name}' after full backup...")
-            try:
-                start_result = start_server(server_name, effective_base_dir)
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after backup: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after backup: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if backup_error:
-        # If core backup_all itself failed
-        return {"status": "error", "message": f"Full backup failed: {backup_error}"}
-    elif restart_error_dict:
-        # Backup succeeded, but restart failed
-        return restart_error_dict
-    else:
         return {
             "status": "success",
             "message": f"Full backup completed successfully for server '{server_name}'.",
+            "details": results
         }
-
-
-# --- Restore Functions ---
+    except (MissingArgumentError, FileOperationError, BackupWorldError) as e: # BackupWorldError from core
+        logger.error(f"API: Full backup failed for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Full backup failed: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during full backup for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error during full backup: {e}"}
 
 
 def restore_world(
@@ -576,175 +286,45 @@ def restore_world(
 ) -> Dict[str, str]:
     """
     Restores a server's world directory from a .mcworld backup file.
-
-    Orchestrates optional server stop/start, calls the core restore function,
-    and handles errors.
-
-    Args:
-        server_name: The name of the server.
-        backup_file_path: The full path to the .mcworld backup file.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop server before restore and restart after if it was running.
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}.
-
-    Raises:
-        MissingArgumentError: If `server_name` or `backup_file_path` is empty.
-        FileNotFoundError: If `backup_file_path` does not exist.
-        FileOperationError: If essential settings (BASE_DIR) are missing.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
     if not backup_file_path:
         raise MissingArgumentError("Backup file path cannot be empty.")
-
+    
     backup_filename = os.path.basename(backup_file_path)
-    logger.info(
-        f"Initiating world restore for server '{server_name}' from '{backup_filename}'. Stop/Start: {stop_start_server}"
-    )
+    logger.info(f"API: Initiating world restore for '{server_name}' from '{backup_filename}'. Stop/Start: {stop_start_server}")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
-        # Check backup file existence *before* stopping server
         if not os.path.isfile(backup_file_path):
             raise FileNotFoundError(f"Backup file not found: {backup_file_path}")
-    except (FileOperationError, FileNotFoundError) as e:
-        logger.error(
-            f"Pre-restore check failed for world restore on server '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {
-            "status": "error",
-            "message": f"Configuration error or backup file not found: {e}",
-        }
 
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before world restore..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for world restore..."
-                )
-                stop_result = stop_server(server_name, effective_base_dir)
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for restore: {stop_result.get('message')}"
-                    )
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for world restore: {e}",
-                exc_info=True,
-            )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server for restore: {e}",
-            }
-
-    # --- Core Restore Operation ---
-    restore_error = None
-    try:
-        # Call core restore function (which internally calls import_world)
-        core_backup.restore_server(
-            server_name, backup_file_path, "world", effective_base_dir
-        )
-        logger.info(
-            f"Core world restore function completed for server '{server_name}'."
-        )
-    except (
-        RestoreError,
-        FileOperationError,
-        DirectoryError,
-        DownloadExtractError,
-        InvalidServerNameError,
-    ) as e:
-        # Catch specific errors known to be raised by restore_server/import_world
-        restore_error = e
-        logger.error(
-            f"World restore failed for server '{server_name}' from '{backup_filename}': {e}",
-            exc_info=True,
-        )
-    except Exception as e:
-        restore_error = e
-        logger.error(
-            f"Unexpected error during world restore for server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if restore_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though world restore failed."
-                )
-            else:
-                logger.info(f"Restarting server '{server_name}' after world restore...")
-            try:
-                start_result = start_server(server_name, effective_base_dir)
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after restore: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after restore: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if restore_error:
-        return {"status": "error", "message": f"World restore failed: {restore_error}"}
-    elif restart_error_dict:
-        return restart_error_dict
-    else:
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            # core_world.import_world handles the actual restoration.
+            # It might need the server_name and base_dir to determine target paths correctly.
+            core_world.import_world(server_name, backup_file_path, effective_base_dir)
+        
         return {
             "status": "success",
-            "message": f"World restore from '{backup_filename}' completed successfully.",
+            "message": f"World restore from '{backup_filename}' completed successfully for server '{server_name}'.",
         }
+    except (MissingArgumentError, FileOperationError, FileNotFoundError, DirectoryError, AddonExtractError, RestoreError, InvalidServerNameError) as e:
+        logger.error(f"API: World restore failed for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"World restore failed: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during world restore for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error during world restore: {e}"}
 
 
 def restore_config_file(
     server_name: str,
     backup_file_path: str,
     base_dir: Optional[str] = None,
-    stop_start_server: bool = True,
+    stop_start_server: bool = True, # Usually False for single config
 ) -> Dict[str, str]:
     """
     Restores a specific configuration file for a server from a backup copy.
-
-    Args:
-        server_name: The name of the server.
-        backup_file_path: The full path to the config backup file.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop/start server around restore (usually not necessary).
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}.
-
-    Raises:
-        MissingArgumentError: If `server_name` or `backup_file_path` is empty.
-        FileNotFoundError: If `backup_file_path` does not exist.
-        FileOperationError: If essential settings (BASE_DIR) are missing.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
@@ -752,127 +332,28 @@ def restore_config_file(
         raise MissingArgumentError("Backup file path cannot be empty.")
 
     backup_filename = os.path.basename(backup_file_path)
-    logger.info(
-        f"Initiating config file restore for server '{server_name}' from '{backup_filename}'. Stop/Start: {stop_start_server}"
-    )
+    logger.info(f"API: Initiating config file restore for '{server_name}' from '{backup_filename}'. Stop/Start: {stop_start_server}")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
+        server_install_dir = os.path.join(effective_base_dir, server_name) # Target for restore
+        
         if not os.path.isfile(backup_file_path):
             raise FileNotFoundError(f"Backup file not found: {backup_file_path}")
-    except (FileOperationError, FileNotFoundError) as e:
-        logger.error(
-            f"Pre-restore check failed for config restore on server '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {
-            "status": "error",
-            "message": f"Configuration error or backup file not found: {e}",
-        }
 
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before config restore..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for config restore..."
-                )
-                stop_result = stop_server(server_name, effective_base_dir)
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for restore: {stop_result.get('message')}"
-                    )
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for config restore: {e}",
-                exc_info=True,
-            )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server for restore: {e}",
-            }
-
-    # --- Core Restore Operation ---
-    restore_error = None
-    try:
-        # Call core restore function
-        core_backup.restore_server(
-            server_name, backup_file_path, "config", effective_base_dir
-        )
-        logger.info(
-            f"Core config file restore function completed for server '{server_name}'."
-        )
-    except (
-        RestoreError,
-        FileOperationError,
-        InvalidInputError,
-        FileNotFoundError,
-    ) as e:
-        restore_error = e
-        logger.error(
-            f"Config file restore failed for server '{server_name}' from '{backup_filename}': {e}",
-            exc_info=True,
-        )
-    except Exception as e:
-        restore_error = e
-        logger.error(
-            f"Unexpected error during config file restore for server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if restore_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though config restore failed."
-                )
-            else:
-                logger.info(
-                    f"Restarting server '{server_name}' after config restore..."
-                )
-            try:
-                start_result = start_server(server_name, effective_base_dir)
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after restore: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after restore: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if restore_error:
-        return {
-            "status": "error",
-            "message": f"Config file restore failed: {restore_error}",
-        }
-    elif restart_error_dict:
-        return restart_error_dict
-    else:
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            restored_file = core_backup.restore_config_file_data(backup_file_path, server_install_dir)
+        
         return {
             "status": "success",
-            "message": f"Config file restore from '{backup_filename}' completed successfully.",
+            "message": f"Config file '{os.path.basename(restored_file)}' restored successfully from '{backup_filename}'.",
         }
+    except (MissingArgumentError, FileOperationError, FileNotFoundError, InvalidInputError) as e:
+        logger.error(f"API: Config file restore failed for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Config file restore failed: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during config file restore for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error during config file restore: {e}"}
 
 
 def restore_all(
@@ -880,309 +361,124 @@ def restore_all(
 ) -> Dict[str, str]:
     """
     Restores the server's world and configuration files from the latest available backups.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop server before restore and restart after if it was running.
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}. Will report error if any part fails.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
-
-    logger.info(
-        f"Initiating restore_all for server '{server_name}'. Stop/Start: {stop_start_server}"
-    )
+    logger.info(f"API: Initiating restore_all for server '{server_name}'. Stop/Start: {stop_start_server}")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
-        # Check backup dir setting early
-        if not settings.get("BACKUP_DIR"):
-            raise FileOperationError("BACKUP_DIR setting missing.")
-    except FileOperationError as e:
-        logger.error(
-            f"Configuration error preventing restore_all for '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {"status": "error", "message": f"Configuration error: {e}"}
+        # Core restore_all_server_data checks BACKUP_DIR
 
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before restore_all..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for restore_all..."
-                )
-                stop_result = stop_server(server_name, effective_base_dir)
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for restore: {stop_result.get('message')}"
-                    )
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for restore_all: {e}",
-                exc_info=True,
-            )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server for restore: {e}",
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            results = core_backup.restore_all_server_data(server_name, effective_base_dir)
+
+        if not results: # If core returned empty, means no backup dir
+             return {
+                "status": "success", # Or "info"
+                "message": f"No backups found for server '{server_name}'. Nothing restored."
             }
 
-    # --- Core Restore Operation ---
-    restore_error = None
-    try:
-        # Call core restore_all function
-        core_backup.restore_all(server_name, effective_base_dir)
-        logger.info(f"Core restore_all function completed for server '{server_name}'.")
-    except RestoreError as e:  # Catch the specific error from core restore_all
-        restore_error = e
-        logger.error(
-            f"Restore all failed for server '{server_name}': {e}", exc_info=True
-        )
-    except (
-        FileOperationError,
-        DirectoryError,
-        MissingArgumentError,
-    ) as e:  # Other possible core errors
-        restore_error = e
-        logger.error(
-            f"Restore all failed for server '{server_name}': {e}", exc_info=True
-        )
-    except Exception as e:
-        restore_error = e
-        logger.error(
-            f"Unexpected error during restore_all for server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if restore_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though restore_all failed."
-                )
-            else:
-                logger.info(f"Restarting server '{server_name}' after restore_all...")
-            try:
-                start_result = start_server(server_name, effective_base_dir)
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after restore: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after restore: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if restore_error:
-        # Use the message from the caught RestoreError if available
-        error_message = getattr(restore_error, "message", str(restore_error))
-        return {"status": "error", "message": f"Restore all failed: {error_message}"}
-    elif restart_error_dict:
-        return restart_error_dict
-    else:
+        failed_components = [comp for comp, path in results.items() if path is None]
+        if failed_components:
+             return {
+                "status": "error",
+                "message": f"Restore_all for '{server_name}' completed with errors. Failed components: {', '.join(failed_components)}.",
+                "details": results
+            }
         return {
             "status": "success",
-            "message": f"Restore all completed successfully for server '{server_name}'.",
+            "message": f"Restore_all completed successfully for server '{server_name}'.",
+            "details": results
         }
+    except (MissingArgumentError, FileOperationError, RestoreError) as e: # RestoreError from core
+        logger.error(f"API: Restore_all failed for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Restore_all failed: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during restore_all for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error during restore_all: {e}"}
 
 
 def prune_old_backups(
     server_name: str, base_dir: Optional[str] = None, backup_keep: Optional[int] = None
 ) -> Dict[str, str]:
     """
-    Prunes old backups (world, properties, json) for a specific server,
-    keeping a configured number of the most recent backups for each type.
-
-    Args:
-        server_name: The name of the server whose backups should be pruned.
-        base_dir: Optional. Base directory for server installations (needed to find world name).
-                  Uses config default if None.
-        backup_keep: Optional. How many backups of each type to keep. If None, uses
-                     the 'BACKUP_KEEP' value from application settings.
-
-    Returns:
-        A dictionary indicating the outcome: {"status": "success", "message": ...} or
-        {"status": "error", "message": ...}. Will report error if any pruning step fails.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        ValueError: If `backup_keep` (or the setting value) is not a valid integer >= 0.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing.
+    Prunes old backups for a specific server.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
-
-    logger.info(f"Initiating pruning of old backups for server '{server_name}'.")
+    logger.info(f"API: Initiating pruning of old backups for server '{server_name}'.")
 
     try:
-        effective_base_dir = get_base_dir(base_dir)
+        effective_base_dir = get_base_dir(base_dir) # Needed for world name for prefix
         backup_base_dir = settings.get("BACKUP_DIR")
         if not backup_base_dir:
             raise FileOperationError("BACKUP_DIR setting missing.")
-
         server_backup_dir = os.path.join(backup_base_dir, server_name)
 
-        # Determine how many backups to keep
         effective_backup_keep: int
         if backup_keep is None:
-            keep_setting = settings.get("BACKUP_KEEP", 3)  # Default to 3
+            keep_setting = settings.get("BACKUP_KEEP", 3)
             try:
                 effective_backup_keep = int(keep_setting)
-                if effective_backup_keep < 0:
-                    raise ValueError("Cannot be negative")
-                logger.debug(f"Using BACKUP_KEEP setting: {effective_backup_keep}")
-            except (ValueError, TypeError) as e:
-                logger.error(
-                    f"Invalid BACKUP_KEEP setting value '{keep_setting}': {e}. Must be a non-negative integer."
-                )
-                raise ValueError(f"Invalid BACKUP_KEEP setting: {e}") from e
+                if effective_backup_keep < 0: raise ValueError()
+            except (ValueError, TypeError):
+                raise ValueError(f"Invalid BACKUP_KEEP setting: '{keep_setting}'. Must be non-negative integer.")
         else:
-            # Use provided value after validation
             try:
                 effective_backup_keep = int(backup_keep)
-                if effective_backup_keep < 0:
-                    raise ValueError("Cannot be negative")
-                logger.debug(
-                    f"Using provided backup_keep value: {effective_backup_keep}"
-                )
-            except (ValueError, TypeError) as e:
-                logger.error(
-                    f"Invalid backup_keep parameter value '{backup_keep}': {e}. Must be a non-negative integer."
-                )
-                raise ValueError(f"Invalid backup_keep parameter: {e}") from e
+                if effective_backup_keep < 0: raise ValueError()
+            except (ValueError, TypeError):
+                raise ValueError(f"Invalid backup_keep parameter: '{backup_keep}'. Must be non-negative integer.")
 
         if not os.path.isdir(server_backup_dir):
-            logger.info(
-                f"Backup directory '{server_backup_dir}' does not exist. Nothing to prune."
-            )
-            return {
-                "status": "success",
-                "message": "No backup directory found, nothing to prune.",
-            }
+            return {"status": "success", "message": "No backup directory found, nothing to prune."}
 
-        # --- Prune Different Backup Types ---
         pruning_errors = []
 
-        # 1. Prune World Backups (*.mcworld)
-        logger.debug("Pruning world backups...")
-        world_name = None
+        # 1. World Backups
+        world_name_prefix = ""
         try:
-            world_name_result = get_world_name(server_name, effective_base_dir)
-            if world_name_result.get("status") == "success":
-                world_name = world_name_result["world_name"]
-            else:
-                logger.warning(
-                    f"Could not determine world name for server '{server_name}'. Pruning *.mcworld without specific prefix."
-                )
+            world_name_res = api_get_world_name(server_name, effective_base_dir)
+            if world_name_res.get("status") == "success":
+                world_name_prefix = f"{world_name_res['world_name']}_backup_"
         except Exception as e:
-            logger.warning(
-                f"Error getting world name for prefix: {e}. Pruning *.mcworld without specific prefix.",
-                exc_info=True,
-            )
-
+            logger.warning(f"Could not determine world name for prefixing prune: {e}")
+        
         try:
-            core_backup.prune_old_backups(
-                backup_dir=server_backup_dir,
-                backup_keep=effective_backup_keep,
-                file_prefix=(
-                    f"{world_name}_backup_" if world_name else ""
-                ),  # Use prefix if name found
-                file_extension="mcworld",
-            )
+            core_backup.prune_old_backups(server_backup_dir, effective_backup_keep, world_name_prefix, "mcworld")
         except Exception as e:
-            logger.error(
-                f"Error pruning world backups for server '{server_name}': {e}",
-                exc_info=True,
-            )
-            pruning_errors.append(f"World backups ({e})")
+            pruning_errors.append(f"World backups ({type(e).__name__})")
+            logger.error(f"Error pruning world backups for '{server_name}': {e}", exc_info=True)
 
-        # 2. Prune Properties Backups (server_backup_*.properties)
-        logger.debug("Pruning server.properties backups...")
-        try:
-            core_backup.prune_old_backups(
-                backup_dir=server_backup_dir,
-                backup_keep=effective_backup_keep,
-                file_prefix="server_backup_",
-                file_extension="properties",
-            )
-        except Exception as e:
-            logger.error(
-                f"Error pruning server.properties backups for server '{server_name}': {e}",
-                exc_info=True,
-            )
-            pruning_errors.append(f"Properties backups ({e})")
+        # 2. Config Backups (properties and json)
+        config_file_types = { # prefix: extension
+            "server_backup_": "properties",
+            "allowlist_backup_": "json",
+            "permissions_backup_": "json",
+            # Add other specific config backup prefixes if they exist
+        }
+        for prefix, ext in config_file_types.items():
+            try:
+                core_backup.prune_old_backups(server_backup_dir, effective_backup_keep, prefix, ext)
+            except Exception as e:
+                pruning_errors.append(f"Config backups ({prefix}*.{ext}) ({type(e).__name__})")
+                logger.error(f"Error pruning {prefix}*.{ext} for '{server_name}': {e}", exc_info=True)
+        
+        # Generic JSON catch-all (if needed, be careful with prefixes)
+        # try:
+        #     core_backup.prune_old_backups(server_backup_dir, effective_backup_keep, file_prefix="", file_extension="json")
+        # except Exception as e:
+        #     pruning_errors.append(f"Generic JSON backups ({type(e).__name__})")
 
-        # 3. Prune JSON Backups (*_backup_*.json) - Prune all JSON together for simplicity
-        logger.debug("Pruning JSON config backups...")
-        try:
-            core_backup.prune_old_backups(
-                backup_dir=server_backup_dir,
-                backup_keep=effective_backup_keep,
-                file_prefix="",  # Match any prefix ending in _backup_
-                file_extension="json",
-            )
-        except Exception as e:
-            logger.error(
-                f"Error pruning JSON backups for server '{server_name}': {e}",
-                exc_info=True,
-            )
-            pruning_errors.append(f"JSON backups ({e})")
-
-        # --- Final Result ---
         if pruning_errors:
-            error_summary = "; ".join(pruning_errors)
-            logger.error(
-                f"Pruning completed with errors for server '{server_name}': {error_summary}"
-            )
-            return {
-                "status": "error",
-                "message": f"Pruning failed for some backup types: {error_summary}",
-            }
-        else:
-            logger.info(
-                f"Backup pruning completed successfully for server '{server_name}'."
-            )
-            return {
-                "status": "success",
-                "message": f"Backup pruning completed for server '{server_name}'.",
-            }
+            return {"status": "error", "message": f"Pruning completed with errors: {'; '.join(pruning_errors)}"}
+        
+        return {"status": "success", "message": f"Backup pruning completed for server '{server_name}'."}
 
-    except (ValueError, FileOperationError) as e:  # Catch setup/config errors
-        logger.error(
-            f"Cannot prune backups for server '{server_name}': {e}", exc_info=True
-        )
-        return {"status": "error", "message": f"Configuration or input error: {e}"}
-    except Exception as e:  # Catch unexpected errors
-        logger.error(
-            f"Unexpected error during backup pruning for server '{server_name}': {e}",
-            exc_info=True,
-        )
+    except (MissingArgumentError, ValueError, FileOperationError, InvalidInputError) as e:
+        logger.error(f"API: Cannot prune backups for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Pruning setup error: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error during backup pruning for '{server_name}': {e}", exc_info=True)
         return {"status": "error", "message": f"Unexpected error during pruning: {e}"}

--- a/src/bedrock_server_manager/api/server.py
+++ b/src/bedrock_server_manager/api/server.py
@@ -201,10 +201,10 @@ def start_server(
                     )
 
                 launcher_pid_dir = os.path.join(
-                    app_config_dir, server_name, "launcher_pids"
+                    app_config_dir, server_name
                 )
                 os.makedirs(launcher_pid_dir, exist_ok=True)
-                launcher_pid_filename = f"{server_name}_launcher.pid"
+                launcher_pid_filename = f"bedrock_{server_name}.pid"
                 launcher_pid_file_path = os.path.join(
                     launcher_pid_dir, launcher_pid_filename
                 )

--- a/src/bedrock_server_manager/api/server.py
+++ b/src/bedrock_server_manager/api/server.py
@@ -3,7 +3,7 @@
 Provides API-level functions for managing Bedrock server instances.
 
 This acts as an interface layer, orchestrating calls to core server management
-functions (`server_base`, `system_linux`, etc.) and returning structured
+functions (from core.server.server, core.system, etc.) and returning structured
 dictionary responses indicating success or failure, suitable for use by web routes
 or other higher-level application logic.
 """
@@ -18,7 +18,9 @@ import time
 from bedrock_server_manager.utils.general import get_base_dir
 from bedrock_server_manager.config.settings import settings
 from bedrock_server_manager.utils.blocked_commands import API_COMMAND_BLACKLIST
-from bedrock_server_manager.core.server import server as server_base
+from bedrock_server_manager.core.server import (
+    server as server_base,
+)  # Alias for core server functions
 from bedrock_server_manager.core.system import (
     base as system_base,
     linux as system_linux,
@@ -90,7 +92,12 @@ def write_server_config(
             "status": "success",
             "message": f"Configuration key '{key}' updated successfully.",
         }
-    except (FileOperationError, InvalidInputError, InvalidServerNameError) as e:
+    except (
+        FileOperationError,
+        InvalidInputError,
+        InvalidServerNameError,
+        MissingArgumentError,
+    ) as e:  # Added MissingArgumentError
         # Catch specific known errors from the core function
         logger.error(
             f"Failed to write server config for '{server_name}': {e}", exc_info=True
@@ -110,7 +117,7 @@ def write_server_config(
 
 def start_server(server_name: str, base_dir: Optional[str] = None) -> Dict[str, str]:
     """
-    Starts the specified Bedrock server using the BedrockServer class.
+    Starts the specified Bedrock server using the core server functions.
 
     Args:
         server_name: The name of the server to start.
@@ -122,17 +129,21 @@ def start_server(server_name: str, base_dir: Optional[str] = None) -> Dict[str, 
     Raises:
         MissingArgumentError: If `server_name` is empty.
         InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
+        FileOperationError: If `base_dir` cannot be determined or essential settings are missing.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
     logger.info(f"Attempting to start server '{server_name}'...")
     try:
-        effective_base_dir = get_base_dir(base_dir)
+        effective_base_dir = get_base_dir(
+            base_dir
+        )  # Used for initial check_if_server_is_running
 
-        # Check if already running before creating BedrockServer instance
-        if system_base.is_server_running(server_name, effective_base_dir):
+        # Check if already running before attempting to start
+        # Note: server_base.start_server also has this check, but checking here
+        # can provide a slightly different API response path.
+        if server_base.check_if_server_is_running(server_name):
             logger.warning(
                 f"Server '{server_name}' is already running. Start request ignored."
             )
@@ -141,25 +152,29 @@ def start_server(server_name: str, base_dir: Optional[str] = None) -> Dict[str, 
                 "message": f"Server '{server_name}' is already running.",
             }
 
-        # Create instance (raises ServerNotFoundError if executable missing)
-        # Pass only server_name, let the class determine paths
-        bedrock_server = server_base.BedrockServer(server_name)
-        # Call start method (raises ServerStartError, CommandNotFoundError)
-        bedrock_server.start()
+        # Call the standalone start function from core.server.server
+        server_base.start_server(server_name)
         logger.info(f"Server '{server_name}' started successfully.")
         return {
             "status": "success",
             "message": f"Server '{server_name}' started successfully.",
         }
 
-    # Catch specific, expected exceptions from BedrockServer init/start
-    except (ServerNotFoundError, ServerStartError, CommandNotFoundError) as e:
+    # Catch specific, expected exceptions from server_base.start_server or setup
+    except (
+        ServerNotFoundError,
+        ServerStartError,
+        CommandNotFoundError,
+        MissingArgumentError,
+    ) as e:  # Added MissingArgumentError
         logger.error(f"Failed to start server '{server_name}': {e}", exc_info=True)
         return {
             "status": "error",
             "message": f"Failed to start server '{server_name}': {e}",
         }
-    except FileOperationError as e:  # Catch error from get_base_dir
+    except (
+        FileOperationError
+    ) as e:  # Catch error from get_base_dir or core if settings are missing
         logger.error(
             f"Configuration error preventing server start for '{server_name}': {e}",
             exc_info=True,
@@ -181,6 +196,7 @@ def systemd_start_server(
 ) -> Dict[str, str]:
     """
     Starts the Bedrock server using the Linux-specific screen method (typically via systemd).
+    This function remains largely the same as it calls os-specific core functions directly.
 
     Args:
         server_name: The name of the server to start.
@@ -209,6 +225,7 @@ def systemd_start_server(
         effective_base_dir = get_base_dir(base_dir)
 
         # Check if already running
+        # system_base.is_server_running is still a valid check here
         if system_base.is_server_running(server_name, effective_base_dir):
             logger.warning(
                 f"Server '{server_name}' is already running (systemd start check)."
@@ -220,7 +237,9 @@ def systemd_start_server(
 
         # Call the Linux-specific start function
         server_dir = os.path.join(effective_base_dir, server_name)
-        system_linux._systemd_start_server(server_name, server_dir)
+        system_linux._systemd_start_server(
+            server_name, server_dir
+        )  # This is an OS-specific core function
         logger.info(
             f"Server '{server_name}' started successfully via systemd/screen method."
         )
@@ -257,7 +276,7 @@ def systemd_start_server(
 
 def stop_server(server_name: str, base_dir: Optional[str] = None) -> Dict[str, str]:
     """
-    Stops the specified Bedrock server using the BedrockServer class.
+    Stops the specified Bedrock server using the core server functions.
 
     Args:
         server_name: The name of the server to stop.
@@ -269,30 +288,29 @@ def stop_server(server_name: str, base_dir: Optional[str] = None) -> Dict[str, s
     Raises:
         MissingArgumentError: If `server_name` is empty.
         InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
+        FileOperationError: If `base_dir` cannot be determined or essential settings missing.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
     logger.info(f"Attempting to stop server '{server_name}'...")
     try:
-        effective_base_dir = get_base_dir(base_dir)
+        effective_base_dir = get_base_dir(
+            base_dir
+        )  # Used for initial check_if_server_is_running
 
-        # Check if not running before creating instance
-        if not system_base.is_server_running(server_name, effective_base_dir):
+        # Check if not running before attempting to stop
+        if not server_base.check_if_server_is_running(server_name):
             logger.warning(
                 f"Server '{server_name}' is not running. Stop request ignored."
             )
-            # Return success as the desired state (stopped) is achieved
             return {
-                "status": "success",
+                "status": "success",  # Desired state (stopped) is achieved
                 "message": f"Server '{server_name}' was already stopped.",
             }
 
-        # Create instance (raises ServerNotFoundError if executable missing but server IS running)
-        bedrock_server = server_base.BedrockServer(server_name)
-        # Call stop method (raises ServerStopError, SendCommandError, CommandNotFoundError)
-        bedrock_server.stop()
+        # Call the standalone stop function from core.server.server
+        server_base.stop_server(server_name)
         logger.info(f"Server '{server_name}' stopped successfully.")
         return {
             "status": "success",
@@ -300,23 +318,22 @@ def stop_server(server_name: str, base_dir: Optional[str] = None) -> Dict[str, s
         }
 
     except (
-        ServerNotFoundError,
+        ServerNotFoundError,  # This can be raised by stop_server if executable is gone but process was seen
         ServerStopError,
         SendCommandError,
         CommandNotFoundError,
+        MissingArgumentError,  # from stop_server if server_name is somehow empty (should be caught above)
     ) as e:
         logger.error(f"Failed to stop server '{server_name}': {e}", exc_info=True)
-        # If ServerNotFoundError happens here, it means process is running but exe is gone - report specific error
-        if isinstance(e, ServerNotFoundError):
-            return {
-                "status": "error",
-                "message": f"Server '{server_name}' process found but executable missing. Stop failed.",
-            }
+        # ServerNotFoundError case needs explicit handling for message if desired.
+        # server_base.stop_server itself will raise ServerNotFoundError if _get_server_details fails.
         return {
             "status": "error",
             "message": f"Failed to stop server '{server_name}': {e}",
         }
-    except FileOperationError as e:  # Catch error from get_base_dir
+    except (
+        FileOperationError
+    ) as e:  # Catch error from get_base_dir or core if settings are missing
         logger.error(
             f"Configuration error preventing server stop for '{server_name}': {e}",
             exc_info=True,
@@ -337,6 +354,7 @@ def systemd_stop_server(
 ) -> Dict[str, str]:
     """
     Stops the Bedrock server using the Linux-specific screen method (typically via systemd).
+    This function remains largely the same as it calls os-specific core functions directly.
 
     Args:
         server_name: The name of the server to stop.
@@ -376,7 +394,9 @@ def systemd_stop_server(
 
         # Call the Linux-specific stop function
         server_dir = os.path.join(effective_base_dir, server_name)
-        system_linux._systemd_stop_server(server_name, server_dir)
+        system_linux._systemd_stop_server(
+            server_name, server_dir
+        )  # This is an OS-specific core function
         logger.info(
             f"Server '{server_name}' stop command sent successfully via systemd/screen method."
         )
@@ -432,7 +452,7 @@ def restart_server(
     Raises:
         MissingArgumentError: If `server_name` is empty.
         InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
+        FileOperationError: If `base_dir` cannot be determined or essential settings are missing.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
@@ -441,17 +461,17 @@ def restart_server(
         f"Initiating restart for server '{server_name}'. Send message: {send_message}"
     )
     try:
-        effective_base_dir = get_base_dir(base_dir)
+        effective_base_dir = get_base_dir(base_dir)  # Used for initial check
 
-        is_running = system_base.is_server_running(server_name, effective_base_dir)
+        # Use core check_if_server_is_running
+        is_running = server_base.check_if_server_is_running(server_name)
 
         if not is_running:
             logger.info(
                 f"Server '{server_name}' was not running. Attempting to start..."
             )
-            # Just call start_server API function
+            # Just call start_server API function (which itself calls core start_server)
             start_result = start_server(server_name, effective_base_dir)
-            # Adjust message slightly for restart context
             if start_result.get("status") == "success":
                 start_result["message"] = (
                     f"Server '{server_name}' was not running and was started."
@@ -468,10 +488,9 @@ def restart_server(
                     f"Attempting to send restart warning message to server '{server_name}'."
                 )
                 try:
-                    # Create instance just to send command
-                    bedrock_server = server_base.BedrockServer(server_name)
-                    bedrock_server.send_command(
-                        "say Server restarting in 10 seconds..."
+                    # Use core standalone send_server_command
+                    server_base.send_server_command(
+                        server_name, "say Server restarting in 10 seconds..."
                     )
                     logger.info(
                         f"Sent restart warning to server '{server_name}'. Waiting 10s..."
@@ -480,15 +499,15 @@ def restart_server(
                 except (
                     ServerNotFoundError,
                     SendCommandError,
-                    ServerNotRunningError,
+                    ServerNotRunningError,  # Should not happen if is_running was true, but possible race
                     CommandNotFoundError,
+                    MissingArgumentError,  # from send_server_command
                 ) as msg_err:
-                    # Log warning but don't fail the whole restart if message send fails
                     logger.warning(
                         f"Could not send restart warning message to server '{server_name}': {msg_err}. Proceeding with restart.",
                         exc_info=True,
                     )
-                except Exception as msg_err:
+                except Exception as msg_err:  # Catch other unexpected errors
                     logger.warning(
                         f"Unexpected error sending restart warning message to server '{server_name}': {msg_err}. Proceeding with restart.",
                         exc_info=True,
@@ -496,49 +515,50 @@ def restart_server(
 
             # --- Stop Server ---
             logger.debug(f"Stopping server '{server_name}' for restart...")
-            stop_result = stop_server(server_name, effective_base_dir)
+            stop_result = stop_server(
+                server_name, effective_base_dir
+            )  # Calls API stop_server
             if stop_result.get("status") == "error":
                 logger.error(
                     f"Restart failed: Could not stop server '{server_name}'. Error: {stop_result.get('message')}"
                 )
-                # Append context to the error message
                 stop_result["message"] = (
                     f"Restart failed during stop phase: {stop_result.get('message')}"
                 )
                 return stop_result
 
-            # Optional delay between stop and start
             logger.debug("Waiting briefly before restarting...")
-            time.sleep(3)  # Short delay
+            time.sleep(3)
 
             # --- Start Server ---
             logger.debug(f"Starting server '{server_name}' after stop...")
-            start_result = start_server(server_name, effective_base_dir)
+            start_result = start_server(
+                server_name, effective_base_dir
+            )  # Calls API start_server
             if start_result.get("status") == "error":
                 logger.error(
                     f"Restart failed: Could not start server '{server_name}' after stopping. Error: {start_result.get('message')}"
                 )
-                # Append context to the error message
                 start_result["message"] = (
                     f"Restart failed during start phase: {start_result.get('message')}"
                 )
                 return start_result
 
-            # If start was successful
             logger.info(f"Server '{server_name}' restarted successfully.")
             return {
                 "status": "success",
                 "message": f"Server '{server_name}' restarted successfully.",
             }
 
-    except FileOperationError as e:  # Catch error from get_base_dir
+    except (
+        FileOperationError
+    ) as e:  # Catch error from get_base_dir or core functions if settings missing
         logger.error(
             f"Configuration error preventing server restart for '{server_name}': {e}",
             exc_info=True,
         )
         return {"status": "error", "message": f"Configuration error: {e}"}
     except Exception as e:
-        # Catch unexpected errors during the restart orchestration
         logger.error(
             f"Unexpected error during restart process for server '{server_name}': {e}",
             exc_info=True,
@@ -547,16 +567,20 @@ def restart_server(
 
 
 def send_command(
-    server_name: str, command: str, base_dir: Optional[str] = None
+    server_name: str,
+    command: str,
+    base_dir: Optional[
+        str
+    ] = None,  # base_dir not directly used by core send_server_command
 ) -> Dict[str, str]:
     """
-    Sends a command to a running Bedrock server instance.
+    Sends a command to a running Bedrock server instance using core functions.
     Certain commands defined in the `API_COMMAND_BLACKLIST` setting may be blocked.
 
     Args:
         server_name: The name of the target server.
         command: The command string to send to the server console.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
+        base_dir: Optional. Base directory for server installations. (Not directly used by core send_server_command but kept for API consistency if needed elsewhere).
 
     Returns:
         A dictionary: `{"status": "success", "message": ...}`.
@@ -566,8 +590,8 @@ def send_command(
         MissingArgumentError: If `server_name` or `command` is empty.
         InvalidServerNameError: If `server_name` is invalid.
         BlockedCommandError: If the command is forbidden by the blacklist configuration.
-        FileOperationError: If `base_dir` cannot be determined.
-        ServerNotFoundError: If the server executable is missing.
+        FileOperationError: If `base_dir` cannot be determined (if used) or essential settings missing for core.
+        ServerNotFoundError: If the server executable is missing (checked by core).
         ServerNotRunningError: If the target server process isn't running or reachable.
         SendCommandError: If sending the command via the OS mechanism fails.
         CommandNotFoundError: If required OS commands (e.g., screen) are missing.
@@ -588,12 +612,15 @@ def send_command(
     )
 
     # --- Blacklist Check ---
-    blacklist = API_COMMAND_BLACKLIST
+    blacklist = API_COMMAND_BLACKLIST  # This is from settings
+    # Ensure API_COMMAND_BLACKLIST is actually loaded in settings
+    # For safety, could default to an empty list if not found, or raise specific config error.
     if not isinstance(blacklist, list):
-        logger.warning(f"Configuration key '{blacklist}' is not a list")
-        raise InvalidInputError(f"Configuration key '{blacklist}' is not a list")
+        logger.warning(
+            f"API_COMMAND_BLACKLIST setting is not a list or not found. Defaulting to empty list for safety."
+        )
+        blacklist = []  # Or raise ConfigurationError
 
-    # Normalize command for checking (lowercase, strip leading '/')
     command_check = command_clean.lower()
     if command_check.startswith("/"):
         command_check = command_check[1:]
@@ -606,18 +633,14 @@ def send_command(
             logger.warning(
                 f"Blocked command attempt for server '{server_name}': {error_msg}"
             )
-            # Raise the specific exception instead of returning an error dict
             raise BlockedCommandError(error_msg)
     # --- End Blacklist Check ---
 
     try:
-        effective_base_dir = get_base_dir(base_dir)
+        # effective_base_dir = get_base_dir(base_dir) # Not strictly needed if send_server_command handles its paths
 
-        # Create instance (raises ServerNotFoundError if executable missing)
-        bedrock_server = server_base.BedrockServer(server_name)
-
-        # Send command (raises various errors on failure)
-        bedrock_server.send_command(command_clean)  # Send the original stripped command
+        # Call the standalone send_server_command from core.server.server
+        server_base.send_server_command(server_name, command_clean)
 
         logger.info(
             f"Command '{command_clean}' sent successfully to server '{server_name}'."
@@ -627,36 +650,33 @@ def send_command(
             "message": f"Command '{command_clean}' sent successfully.",
         }
 
-    # Re-raise specific exceptions caught from BedrockServer or setup
-    # The calling route handler will now need to catch these.
     except (
         ServerNotFoundError,
         ServerNotRunningError,
         SendCommandError,
         CommandNotFoundError,
-        MissingArgumentError,
-        FileOperationError,
-        InvalidServerNameError,
+        MissingArgumentError,  # From send_server_command if args are empty
+        FileOperationError,  # From send_server_command if settings are missing
+        InvalidServerNameError,  # From send_server_command
     ) as e:
         logger.error(
             f"Failed to send command to server '{server_name}': {e}", exc_info=True
         )
-        raise  # Re-raise the original exception
+        raise  # Re-raise the original exception to be handled by route
 
     except Exception as e:
-        # Catch unexpected errors and wrap them potentially
         logger.error(
             f"Unexpected error sending command to server '{server_name}': {e}",
             exc_info=True,
         )
-        # Re-raise as a generic error or a specific internal error type if you have one
+        # Re-raise as a generic error or a specific internal error type
         raise RuntimeError(f"Unexpected error sending command: {e}") from e
 
 
 def delete_server_data(
     server_name: str,
     base_dir: Optional[str] = None,
-    config_dir: Optional[str] = None,
+    config_dir: Optional[str] = None,  # config_dir passed to core delete_server_data
     stop_if_running: bool = True,
 ) -> Dict[str, str]:
     """
@@ -676,7 +696,7 @@ def delete_server_data(
     Raises:
         MissingArgumentError: If `server_name` is empty.
         InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing.
+        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR, _config_dir for core) are missing.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
@@ -686,9 +706,11 @@ def delete_server_data(
     )
     try:
         effective_base_dir = get_base_dir(base_dir)
-        # Ensure backup dir setting exists for core delete function
+        # Ensure backup dir setting exists for core delete function (core already checks _config_dir)
         if not settings.get("BACKUP_DIR"):
-            raise FileOperationError("BACKUP_DIR setting missing.")
+            raise FileOperationError(
+                "BACKUP_DIR setting missing in application configuration."
+            )
 
         # --- Stop Server (Optional) ---
         if stop_if_running:
@@ -696,15 +718,14 @@ def delete_server_data(
                 f"Checking if server '{server_name}' needs to be stopped before deletion..."
             )
             try:
-                if system_base.is_server_running(server_name, effective_base_dir):
+                # Use core check_if_server_is_running
+                if server_base.check_if_server_is_running(server_name):
                     logger.info(
                         f"Server '{server_name}' is running. Stopping before deletion..."
                     )
-                    stop_result = stop_server(
-                        server_name, effective_base_dir
-                    )  # Call API stop function
+                    # Call API stop_server function (which calls core stop_server)
+                    stop_result = stop_server(server_name, effective_base_dir)
                     if stop_result.get("status") == "error":
-                        # If stop fails, abort deletion to prevent data issues with running server
                         error_msg = f"Failed to stop server '{server_name}' before deletion: {stop_result.get('message')}. Deletion aborted."
                         logger.error(error_msg)
                         return {"status": "error", "message": error_msg}
@@ -713,18 +734,19 @@ def delete_server_data(
                     logger.debug(
                         f"Server '{server_name}' is not running. No stop needed."
                     )
-            except Exception as e:
-                # Catch unexpected errors during stop check/attempt
+            except (
+                Exception
+            ) as e:  # Catch unexpected errors during the stop check/attempt
                 error_msg = f"Error occurred while stopping server '{server_name}' before deletion: {e}. Deletion aborted."
                 logger.error(error_msg, exc_info=True)
                 return {"status": "error", "message": error_msg}
 
         # --- Core Deletion Operation ---
         logger.debug(f"Proceeding with deletion of data for server '{server_name}'...")
-        # Call core delete function
+        # Call core delete function, passing effective_base_dir and optional config_dir
         server_base.delete_server_data(
-            server_name, effective_base_dir, config_dir
-        )  # Raises DirectoryError on failure
+            server_name, effective_base_dir, config_dir=config_dir
+        )
         logger.info(f"Successfully deleted data for server '{server_name}'.")
         return {
             "status": "success",
@@ -732,19 +754,19 @@ def delete_server_data(
         }
 
     except (DirectoryError, InvalidServerNameError) as e:
-        # Catch specific errors known to be raised by core delete_server_data
         logger.error(
             f"Failed to delete server data for '{server_name}': {e}", exc_info=True
         )
         return {"status": "error", "message": f"Failed to delete server data: {e}"}
-    except FileOperationError as e:  # Catch config/base_dir errors
+    except (
+        FileOperationError
+    ) as e:  # Catches config/base_dir errors from get_base_dir or core
         logger.error(
             f"Configuration error preventing server deletion for '{server_name}': {e}",
             exc_info=True,
         )
         return {"status": "error", "message": f"Configuration error: {e}"}
     except Exception as e:
-        # Catch unexpected errors
         logger.error(
             f"Unexpected error deleting server data for '{server_name}': {e}",
             exc_info=True,

--- a/src/bedrock_server_manager/api/server.py
+++ b/src/bedrock_server_manager/api/server.py
@@ -577,7 +577,7 @@ def restart_server(
                 f"Server '{server_name}' was not running. Attempting to start..."
             )
             # Just call start_server API function (which itself calls core start_server)
-            start_result = start_server(server_name, effective_base_dir)
+            start_result = start_server(server_name, effective_base_dir, "detached")
             if start_result.get("status") == "success":
                 start_result["message"] = (
                     f"Server '{server_name}' was not running and was started."
@@ -639,7 +639,7 @@ def restart_server(
             # --- Start Server ---
             logger.debug(f"Starting server '{server_name}' after stop...")
             start_result = start_server(
-                server_name, effective_base_dir
+                server_name, effective_base_dir, "detached"
             )  # Calls API start_server
             if start_result.get("status") == "error":
                 logger.error(

--- a/src/bedrock_server_manager/api/server.py
+++ b/src/bedrock_server_manager/api/server.py
@@ -200,9 +200,7 @@ def start_server(
                         "Application configuration directory (_config_dir) not set in settings for detached start."
                     )
 
-                launcher_pid_dir = os.path.join(
-                    app_config_dir, server_name
-                )
+                launcher_pid_dir = os.path.join(app_config_dir, server_name)
                 os.makedirs(launcher_pid_dir, exist_ok=True)
                 launcher_pid_filename = f"bedrock_{server_name}.pid"
                 launcher_pid_file_path = os.path.join(

--- a/src/bedrock_server_manager/api/server.py
+++ b/src/bedrock_server_manager/api/server.py
@@ -253,6 +253,7 @@ def start_server(
                             logger.info(
                                 f"Successfully initiated start for systemd service '{service_name}'."
                             )
+
                             return {
                                 "status": "success",
                                 "message": f"Server '{server_name}' (detached mode) started successfully.",
@@ -273,6 +274,7 @@ def start_server(
                     logger.warning(
                         f"Service file for '{server_name}' doesn't exist. Fallback to direct mode..."
                     )
+                    write_server_config(server_name, "start_method", "")
                     server_base.start_server(server_name)
                     logger.info(
                         f"API: Direct start for server '{server_name}' completed successfully."
@@ -341,7 +343,7 @@ def stop_server(
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
-    if mode not in ["direct", "detached"]:
+    if mode not in ["direct", "detached", "", None]:
         raise InvalidInputError(
             f"Invalid stop mode '{mode}'. Must be 'direct' or 'detached'."
         )
@@ -349,10 +351,12 @@ def stop_server(
     if platform.system() == "Windows":
         mode = "direct"  # Normalize mode for Windows
 
+    write_server_config(server_name, "start_method", "")
+
     logger.info(f"Attempting to stop server '{server_name}'...")
 
     try:
-        if mode == "direct":
+        if mode in ["direct", "", None]:
             effective_base_dir = get_base_dir(base_dir)
 
             if not server_base.check_if_server_is_running(server_name):
@@ -366,6 +370,7 @@ def stop_server(
 
             server_base.stop_server(server_name)
             logger.info(f"Server '{server_name}' stopped successfully.")
+
             return {
                 "status": "success",
                 "message": f"Server '{server_name}' stopped successfully.",

--- a/src/bedrock_server_manager/api/server_install_config.py
+++ b/src/bedrock_server_manager/api/server_install_config.py
@@ -43,9 +43,6 @@ from bedrock_server_manager.error import (
 logger = logging.getLogger("bedrock_server_manager")
 
 
-# --- Functions from your previous version (Allowlist, Permissions, Properties Read/Validate) ---
-
-
 def configure_allowlist(
     server_name: str,
     base_dir: Optional[str] = None,

--- a/src/bedrock_server_manager/api/server_install_config.py
+++ b/src/bedrock_server_manager/api/server_install_config.py
@@ -14,14 +14,20 @@ import re
 from typing import Dict, List, Optional, Any
 
 # Local imports
-from bedrock_server_manager.core import downloader
+from bedrock_server_manager.core import downloader as core_downloader
 from bedrock_server_manager.config.settings import settings
 from bedrock_server_manager.utils.general import get_base_dir
-from bedrock_server_manager.api.server import write_server_config, send_command
+from bedrock_server_manager.api.server import (
+    write_server_config as api_write_server_config,
+)
+from bedrock_server_manager.api.server import send_command as api_send_command
 from bedrock_server_manager.api import player as player_api
-from bedrock_server_manager.core.system import base as system_base
-from bedrock_server_manager.core.server import server as server_base
-from bedrock_server_manager.api.utils import validate_server_name_format
+from bedrock_server_manager.core.server import server as core_server_base
+from bedrock_server_manager.core.server import backup as core_backup
+from bedrock_server_manager.api.utils import (
+    _server_stop_start_manager,
+    validate_server_name_format,
+)
 from bedrock_server_manager.error import (
     InvalidServerNameError,
     FileOperationError,
@@ -32,10 +38,12 @@ from bedrock_server_manager.error import (
     DownloadExtractError,
     InternetConnectivityError,
     BackupWorldError,
-    RestoreError,
 )
 
 logger = logging.getLogger("bedrock_server_manager")
+
+
+# --- Functions from your previous version (Allowlist, Permissions, Properties Read/Validate) ---
 
 
 def configure_allowlist(
@@ -46,55 +54,34 @@ def configure_allowlist(
     """
     Configures the allowlist for a specific server. Reads the existing list and
     optionally adds new players if provided.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. The base directory for server installations. Uses config default if None.
-        new_players_data: Optional. A list of dictionaries for new players to add.
-                          Each dictionary must have 'name' (str) and should typically have
-                          'ignoresPlayerLimit' (bool). Defaults to None (no players added).
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "existing_players": List[Dict], "added_players": List[Dict], "message": str}
-        - {"status": "error", "message": str}
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        TypeError: If `new_players_data` is provided but is not a list.
-        FileOperationError: If `base_dir` cannot be determined.
     """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
     if new_players_data is not None and not isinstance(new_players_data, list):
         raise TypeError("If provided, new_players_data must be a list of dictionaries.")
 
-    logger.info(f"Configuring allowlist for server '{server_name}'.")
+    logger.info(f"API: Configuring allowlist for server '{server_name}'.")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
         server_dir = os.path.join(effective_base_dir, server_name)
 
-        # Ensure server directory exists before proceeding
         if not os.path.isdir(server_dir):
             raise DirectoryError(f"Server directory not found: {server_dir}")
 
-        # 1. Read existing allowlist
-        logger.debug("Reading existing allowlist...")
-        existing_players = server_base.configure_allowlist(
-            server_dir
-        )  # Core function reads/returns list
-        logger.debug(f"Found {len(existing_players)} players in existing allowlist.")
+        existing_players = core_server_base.configure_allowlist(server_dir)
+        logger.debug(
+            f"API: Found {len(existing_players)} players in existing allowlist."
+        )
 
     except (FileOperationError, DirectoryError) as e:
         logger.error(
-            f"Failed to read or access allowlist directory for server '{server_name}': {e}",
-            exc_info=True,
+            f"API: Failed to access allowlist for '{server_name}': {e}", exc_info=True
         )
         return {"status": "error", "message": f"Failed to access allowlist: {e}"}
     except Exception as e:
         logger.error(
-            f"Unexpected error reading allowlist for server '{server_name}': {e}",
+            f"API: Unexpected error reading allowlist for '{server_name}': {e}",
             exc_info=True,
         )
         return {
@@ -102,84 +89,76 @@ def configure_allowlist(
             "message": f"Unexpected error reading allowlist: {e}",
         }
 
-    # 2. Process new players if provided
-    added_players_list: List[Dict[str, Any]] = []
+    added_players_list_final: List[Dict[str, Any]] = []
     if new_players_data:
         logger.info(
-            f"Processing {len(new_players_data)} new player entries to potentially add..."
+            f"API: Processing {len(new_players_data)} new player entries for '{server_name}'..."
         )
         existing_names_lower = {
             p.get("name", "").lower() for p in existing_players if isinstance(p, dict)
         }
-        added_names_lower = set()
+        processed_in_batch = set()
 
         for player_entry in new_players_data:
             if (
                 not isinstance(player_entry, dict)
-                or not isinstance(player_entry.get("name"), str)
                 or not player_entry.get("name")
+                or not isinstance(player_entry.get("name"), str)
             ):
-                logger.warning(
-                    f"Skipping invalid player entry in new_players_data (missing/invalid name): {player_entry}"
-                )
+                logger.warning(f"API: Skipping invalid player entry: {player_entry}")
                 continue
-
             player_name = player_entry["name"]
             player_name_lower = player_name.lower()
-
-            if player_name_lower in existing_names_lower:
+            if (
+                player_name_lower in existing_names_lower
+                or player_name_lower in processed_in_batch
+            ):
                 logger.debug(
-                    f"Player '{player_name}' already exists in allowlist. Skipping."
-                )
-                continue
-            if player_name_lower in added_names_lower:
-                logger.debug(
-                    f"Player '{player_name}' already processed in this batch. Skipping duplicate."
+                    f"API: Player '{player_name}' already exists or processed. Skipping."
                 )
                 continue
 
-            # Add default ignoresPlayerLimit if missing (optional, based on need)
-            if "ignoresPlayerLimit" not in player_entry:
-                player_entry["ignoresPlayerLimit"] = False
+            player_obj = {
+                "name": player_name,
+                "ignoresPlayerLimit": player_entry.get("ignoresPlayerLimit", False),
+            }
+            added_players_list_final.append(player_obj)
+            processed_in_batch.add(player_name_lower)
+            logger.debug(f"API: Prepared player '{player_name}' for addition.")
 
-            added_players_list.append(player_entry)
-            added_names_lower.add(player_name_lower)
-            logger.debug(f"Prepared player '{player_name}' for addition.")
-
-        # 3. Add the validated new players if any exist
-        if added_players_list:
+        if added_players_list_final:
             logger.info(
-                f"Adding {len(added_players_list)} new valid players to allowlist..."
+                f"API: Adding {len(added_players_list_final)} new players to allowlist for '{server_name}'..."
             )
             try:
-                # Core function handles writing the file
-                server_base.add_players_to_allowlist(server_dir, added_players_list)
-                message = f"Successfully added {len(added_players_list)} players to allowlist."
-                logger.info(message)
+                core_server_base.add_players_to_allowlist(
+                    server_dir, added_players_list_final
+                )
+                # Optionally send reload command
+                if core_server_base.check_if_server_is_running(
+                    server_name
+                ):  # Pass base_dir if needed
+                    cmd_res = api_send_command(server_name, "allowlist reload")
+                    if cmd_res.get("status") == "error":
+                        logger.warning(
+                            f"API: Failed to send 'allowlist reload' to '{server_name}': {cmd_res.get('message')}"
+                        )
+
+                message = f"Successfully added {len(added_players_list_final)} players."
                 return {
                     "status": "success",
                     "existing_players": existing_players,
-                    "added_players": added_players_list,
+                    "added_players": added_players_list_final,
                     "message": message,
                 }
             except (FileOperationError, TypeError) as e:
                 logger.error(
-                    f"Failed to add players to allowlist file for server '{server_name}': {e}",
+                    f"API: Failed to save allowlist for '{server_name}': {e}",
                     exc_info=True,
                 )
                 return {"status": "error", "message": f"Error saving allowlist: {e}"}
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error adding players for server '{server_name}': {e}",
-                    exc_info=True,
-                )
-                return {
-                    "status": "error",
-                    "message": f"Unexpected error saving allowlist: {e}",
-                }
         else:
-            message = "No new players provided or all provided players were duplicates/invalid."
-            logger.info(message)
+            message = "No new valid players to add."
             return {
                 "status": "success",
                 "existing_players": existing_players,
@@ -187,11 +166,7 @@ def configure_allowlist(
                 "message": message,
             }
     else:
-        # No new players provided, just return existing list
-        message = (
-            "Read existing allowlist successfully. No new players provided to add."
-        )
-        logger.debug(message)
+        message = "Read existing allowlist. No new players provided."
         return {
             "status": "success",
             "existing_players": existing_players,
@@ -203,78 +178,53 @@ def configure_allowlist(
 def remove_player_from_allowlist(
     server_name: str, player_name: str, base_dir: Optional[str] = None
 ) -> Dict[str, Any]:
-    """
-    Removes a specific player from the allowlist of a given server.
-
-    Args:
-        server_name: The name of the server.
-        player_name: The name of the player to remove (case-insensitive).
-        base_dir: Optional. The base directory for server installations. Uses config default if None.
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "message": "Player '...' removed successfully."}
-        - {"status": "success", "message": "Player '...' not found in allowlist."} (Note: success status)
-        - {"status": "error", "message": str} on failure (e.g., file access error).
-
-    Raises:
-        MissingArgumentError: If `server_name` or `player_name` is empty.
-        FileOperationError: If `base_dir` cannot be determined.
-        DirectoryError: If the server directory doesn't exist.
-    """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
     if not player_name:
         raise MissingArgumentError("Player name cannot be empty.")
-
     logger.info(
-        f"Attempting to remove player '{player_name}' from allowlist for server '{server_name}'."
+        f"API: Removing player '{player_name}' from allowlist for '{server_name}'."
     )
-
     try:
         effective_base_dir = get_base_dir(base_dir)
         server_dir = os.path.join(effective_base_dir, server_name)
-
-        # Ensure server directory exists before proceeding
         if not os.path.isdir(server_dir):
             raise DirectoryError(f"Server directory not found: {server_dir}")
 
-        # Call the core function to perform the removal
-        was_removed = server_base.remove_player_from_allowlist(server_dir, player_name)
-
+        was_removed = core_server_base.remove_player_from_allowlist(
+            server_dir, player_name
+        )
         if was_removed:
-            message = f"Player '{player_name}' removed successfully from allowlist for server '{server_name}'."
-            logger.info(message)
-            return {"status": "success", "message": message}
+            if core_server_base.check_if_server_is_running(server_name):
+                cmd_res = api_send_command(server_name, "whitelist reload")
+                if cmd_res.get("status") == "error":
+                    logger.warning(
+                        f"API: Failed to send 'whitelist reload' to '{server_name}': {cmd_res.get('message')}"
+                    )
+            return {
+                "status": "success",
+                "message": f"Player '{player_name}' removed successfully.",
+            }
         else:
-            # Player wasn't found - this is not necessarily a server error,
-            # so return success status but indicate not found.
-            message = f"Player '{player_name}' not found in the allowlist for server '{server_name}'. No changes made."
-            logger.warning(f"API Allowlist Remove: {message}")  # Log as warning
-            return {"status": "success", "message": message}
-
+            return {
+                "status": "success",
+                "message": f"Player '{player_name}' not found in allowlist.",
+            }
     except (FileOperationError, DirectoryError, MissingArgumentError) as e:
-        # Catch specific errors from setup or core function
         logger.error(
-            f"Failed to remove player '{player_name}' from allowlist for server '{server_name}': {e}",
+            f"API: Failed to remove player from allowlist for '{server_name}': {e}",
             exc_info=True,
         )
-        # Re-raise these specific exceptions to be handled by the route's error handlers
-        # Or return an error dict if this API function is the final layer before the route
         return {
             "status": "error",
             "message": f"Failed to process allowlist removal: {e}",
         }
     except Exception as e:
-        # Catch any unexpected errors
         logger.error(
-            f"Unexpected error removing player '{player_name}' for server '{server_name}': {e}",
+            f"API: Unexpected error removing player for '{server_name}': {e}",
             exc_info=True,
         )
-        return {
-            "status": "error",
-            "message": f"Unexpected error removing player from allowlist: {e}",
-        }
+        return {"status": "error", "message": f"Unexpected error: {e}"}
 
 
 def configure_player_permission(
@@ -284,53 +234,31 @@ def configure_player_permission(
     permission: str,
     base_dir: Optional[str] = None,
 ) -> Dict[str, str]:
-    """
-    Configures the permission level for a specific player on a server.
-
-    Updates the `permissions.json` file within the server's directory.
-
-    Args:
-        server_name: The name of the server.
-        xuid: The player's XUID string.
-        player_name: Optional. The player's name (used if adding a new entry).
-        permission: The desired permission level ("member", "operator", or "visitor"). Case-insensitive.
-        base_dir: Optional. The base directory for server installations. Uses config default if None.
-
-    Returns:
-        A dictionary: `{"status": "success", "message": ...}` or `{"status": "error", "message": ...}`.
-
-    Raises:
-        MissingArgumentError: If `server_name`, `xuid`, or `permission` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
-    """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
     if not xuid:
         raise MissingArgumentError("Player XUID cannot be empty.")
     if not permission:
         raise MissingArgumentError("Permission level cannot be empty.")
-    # Core function validates permission value ("operator", "member", "visitor")
-
     logger.info(
-        f"Configuring permission for XUID '{xuid}' on server '{server_name}' to '{permission}'."
+        f"API: Configuring permission for XUID '{xuid}' on '{server_name}' to '{permission}'."
     )
-
     try:
         effective_base_dir = get_base_dir(base_dir)
         server_dir = os.path.join(effective_base_dir, server_name)
-
-        # Delegate to core function which handles file I/O, validation, and logic
-        server_base.configure_permissions(server_dir, xuid, player_name, permission)
-
-        logger.info(
-            f"Successfully configured permission for XUID '{xuid}' on server '{server_name}'."
+        core_server_base.configure_permissions(
+            server_dir, xuid, player_name, permission
         )
+        if core_server_base.check_if_server_is_running(server_name):
+            cmd_res = api_send_command(server_name, "permission reload")
+            if cmd_res.get("status") == "error":
+                logger.warning(
+                    f"API: Failed to send 'permission reload' to '{server_name}': {cmd_res.get('message')}"
+                )
         return {
             "status": "success",
             "message": f"Permission for XUID '{xuid}' set to '{permission.lower()}'.",
         }
-
     except (
         InvalidInputError,
         DirectoryError,
@@ -338,287 +266,157 @@ def configure_player_permission(
         MissingArgumentError,
         InvalidServerNameError,
     ) as e:
-        # Catch specific errors raised by core function or path issues
         logger.error(
-            f"Failed to configure permission for XUID '{xuid}' on server '{server_name}': {e}",
+            f"API: Failed to configure permission for '{server_name}': {e}",
             exc_info=True,
         )
         return {"status": "error", "message": f"Failed to configure permission: {e}"}
     except Exception as e:
-        # Catch unexpected errors
         logger.error(
-            f"Unexpected error configuring permission for XUID '{xuid}' on server '{server_name}': {e}",
+            f"API: Unexpected error configuring permission for '{server_name}': {e}",
             exc_info=True,
         )
-        return {
-            "status": "error",
-            "message": f"Unexpected error configuring permission: {e}",
-        }
+        return {"status": "error", "message": f"Unexpected error: {e}"}
 
 
 def get_server_permissions_data(
     server_name: str,
     base_dir_override: Optional[str] = None,
-    config_dir_override: Optional[str] = None,  # For players.json lookup
+    config_dir_override: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """
-    Retrieves player permission data for a specific server from its permissions.json.
-    Optionally enriches this data with player names from the global players.json.
-
-    Args:
-        server_name: The name of the server.
-
-    Returns:
-        A dictionary:
-        - {"status": "success", "data": {"permissions": List[Dict]}}
-          where each dict in "permissions" is e.g.,
-          {"xuid": "...", "name": "...", "permission_level": "..."}
-        - {"status": "error", "message": str} on failure.
-    """
     if not server_name:
         return {"status": "error", "message": "Server name cannot be empty."}
-
     logger.info(f"API: Getting server permissions data for server '{server_name}'.")
     server_permissions_list_for_ui: List[Dict[str, Any]] = []
     error_messages = []
-    player_name_map: Dict[str, str] = {}  # {xuid: name} from global players.json
-
+    player_name_map: Dict[str, str] = {}
     try:
         effective_server_base_dir = get_base_dir(base_dir_override)
         server_instance_dir = os.path.join(effective_server_base_dir, server_name)
-
         if not os.path.isdir(server_instance_dir):
             raise InvalidServerNameError(
                 f"Server directory not found: {server_instance_dir}"
             )
-
-        # 1. Optionally load global player names for enrichment
         try:
             effective_app_config_dir = (
                 config_dir_override
                 if config_dir_override is not None
                 else getattr(settings, "_config_dir", None)
             )
-            if effective_app_config_dir:  # Only attempt if config_dir is available
+            if effective_app_config_dir:
                 players_response = player_api.get_players_from_json(
                     config_dir=effective_app_config_dir
                 )
                 if players_response.get("status") == "success":
-                    global_players = players_response.get("players", [])
-                    for p_data in global_players:
+                    for p_data in players_response.get("players", []):
                         if p_data.get("xuid") and p_data.get("name"):
                             player_name_map[str(p_data["xuid"])] = str(p_data["name"])
-                    logger.debug(
-                        f"API Layer: Loaded {len(player_name_map)} names from global players.json."
-                    )
                 else:
-                    msg = f"Could not load global player list for name enrichment: {players_response.get('message')}"
-                    logger.warning(msg)
-                    error_messages.append(msg)  # Non-critical for core functionality
-            else:
-                logger.debug(
-                    "API Layer: App config directory not set, skipping global player name lookup."
-                )
-        except Exception as e_players:  # Catch errors during player name lookup
-            msg = f"Error loading global player names: {e_players}"
-            logger.warning(msg, exc_info=True)
-            error_messages.append(msg)
-
-        # 2. Read the server's permissions.json
+                    error_messages.append(
+                        f"Could not load global player list: {players_response.get('message')}"
+                    )
+        except Exception as e_players:
+            error_messages.append(f"Error loading global player names: {e_players}")
         permissions_file_path = os.path.join(server_instance_dir, "permissions.json")
-        logger.debug(
-            f"API Layer: Reading server permissions file: {permissions_file_path}"
-        )
-
         if not os.path.isfile(permissions_file_path):
-            logger.info(
-                f"API Layer: Server permissions file not found at '{permissions_file_path}'. No permissions to list."
-            )
-            # This is not an error if the goal is just to see what's there; an empty list is valid.
-            # If the file MUST exist, this would be an error.
             return {
                 "status": "success",
                 "data": {"permissions": []},
-                "message": (
-                    "Server permissions file not found." if error_messages else None
-                ),  # Add if other warnings
+                "message": "Server permissions file not found.",
             }
-
         try:
             with open(permissions_file_path, "r", encoding="utf-8") as f:
                 content = f.read()
-                if not content.strip():
-                    logger.info(
-                        f"API Layer: Server permissions file '{permissions_file_path}' is empty."
+            if not content.strip():
+                return {
+                    "status": "success",
+                    "data": {"permissions": []},
+                    "message": "Server permissions file is empty.",
+                }
+            permissions_from_file = json.loads(content)
+            if not isinstance(permissions_from_file, list):
+                raise ValueError("Permissions file not a list.")
+            for entry in permissions_from_file:
+                if (
+                    isinstance(entry, dict)
+                    and "xuid" in entry
+                    and "permission" in entry
+                ):
+                    xuid_str = str(entry["xuid"])
+                    name = player_name_map.get(xuid_str, f"Unknown (XUID: {xuid_str})")
+                    server_permissions_list_for_ui.append(
+                        {
+                            "xuid": xuid_str,
+                            "name": name,
+                            "permission_level": str(entry["permission"]),
+                        }
                     )
-                    # Return success, empty list
-                    return {
-                        "status": "success",
-                        "data": {"permissions": []},
-                        "message": (
-                            "; ".join(error_messages) if error_messages else None
-                        ),
-                    }
-
-                permissions_from_file = json.loads(content)
-                if not isinstance(permissions_from_file, list):
-                    raise ValueError(
-                        "Permissions file does not contain a list as expected."
+                else:
+                    logger.warning(
+                        f"API: Skipping malformed entry in '{permissions_file_path}': {entry}"
                     )
-
-                for entry in permissions_from_file:
-                    if (
-                        isinstance(entry, dict)
-                        and "xuid" in entry
-                        and "permission" in entry
-                    ):
-                        xuid_str = str(entry["xuid"])
-                        name = player_name_map.get(
-                            xuid_str, f"Unknown (XUID: {xuid_str})"
-                        )
-                        server_permissions_list_for_ui.append(
-                            {
-                                "xuid": xuid_str,
-                                "name": name,
-                                "permission_level": str(entry["permission"]),
-                            }
-                        )
-                    else:
-                        logger.warning(
-                            f"API Layer: Skipping malformed entry in '{permissions_file_path}': {entry}"
-                        )
-                logger.debug(
-                    f"API Layer: Processed {len(server_permissions_list_for_ui)} entries from '{permissions_file_path}'."
-                )
-
         except (OSError, json.JSONDecodeError, ValueError) as e:
-            # These are critical errors for reading this server's permissions
-            logger.error(
-                f"API Layer: Failed to read or parse server permissions file '{permissions_file_path}': {e}",
-                exc_info=True,
-            )
             return {
                 "status": "error",
                 "message": f"Failed to process server permissions file: {e}",
             }
-
-        # Sort final list for display
         server_permissions_list_for_ui.sort(key=lambda p: p.get("name", "").lower())
-
-        response_data = {"permissions": server_permissions_list_for_ui}
         final_message = (
             "; ".join(error_messages)
             if error_messages
             else "Successfully retrieved server permissions."
         )
-
         return {
             "status": "success",
-            "data": response_data,
+            "data": {"permissions": server_permissions_list_for_ui},
             "message": (
                 final_message
                 if error_messages or not server_permissions_list_for_ui
                 else None
             ),
         }
-
     except (FileOperationError, InvalidServerNameError) as e:
-        logger.error(
-            f"API Layer: Error getting server permissions data for '{server_name}': {e}",
-            exc_info=True,
-        )
         return {"status": "error", "message": str(e)}
     except Exception as e:
-        logger.error(
-            f"API Layer: Unexpected error getting server permissions for '{server_name}': {e}",
-            exc_info=True,
-        )
         return {"status": "error", "message": f"An unexpected error occurred: {e}"}
 
 
 def read_server_properties(
     server_name: str, base_dir: Optional[str] = None
 ) -> Dict[str, Any]:
-    """
-    Reads and parses the `server.properties` file for a given server.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. The base directory for server installations. Uses config default if None.
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "properties": Dict[str, str]} on success.
-        - {"status": "error", "message": str} if the file is not found or cannot be read/parsed.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
-    """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
-
-    logger.debug(f"Reading server.properties for server '{server_name}'...")
+    logger.debug(f"API: Reading server.properties for server '{server_name}'...")
     properties: Dict[str, str] = {}
-
     try:
         effective_base_dir = get_base_dir(base_dir)
         server_properties_path = os.path.join(
             effective_base_dir, server_name, "server.properties"
         )
-
-        logger.debug(f"Attempting to read properties file: {server_properties_path}")
         if not os.path.isfile(server_properties_path):
             raise FileNotFoundError(
-                f"server.properties file not found at: {server_properties_path}"
+                f"server.properties not found: {server_properties_path}"
             )
-
         with open(server_properties_path, "r", encoding="utf-8") as f:
             for line_num, line in enumerate(f, 1):
                 line = line.strip()
-                # Skip empty lines and comments
                 if not line or line.startswith("#"):
                     continue
-                # Split only on the first equals sign
                 parts = line.split("=", 1)
                 if len(parts) == 2:
-                    key = parts[0].strip()
-                    value = parts[1].strip()
-                    properties[key] = value
+                    properties[parts[0].strip()] = parts[1].strip()
                 else:
                     logger.warning(
-                        f"Skipping malformed line {line_num} in '{server_properties_path}': {line}"
+                        f"API: Skipping malformed line {line_num} in '{server_properties_path}': {line}"
                     )
-
-        logger.debug(
-            f"Successfully read and parsed {len(properties)} properties for server '{server_name}'."
-        )
         return {"status": "success", "properties": properties}
-
     except FileNotFoundError as e:
-        logger.error(f"Could not read properties for server '{server_name}': {e}")
-        return {
-            "status": "error",
-            "message": str(e),
-        }  # Return FileNotFoundError message
-    except FileOperationError as e:  # Catch error from get_base_dir
-        logger.error(
-            f"Configuration error preventing reading properties for '{server_name}': {e}",
-            exc_info=True,
-        )
+        return {"status": "error", "message": str(e)}
+    except FileOperationError as e:
         return {"status": "error", "message": f"Configuration error: {e}"}
     except OSError as e:
-        logger.error(
-            f"Failed to read server.properties file '{server_properties_path}': {e}",
-            exc_info=True,
-        )
         return {"status": "error", "message": f"Failed to read server.properties: {e}"}
     except Exception as e:
-        logger.error(
-            f"Unexpected error reading server.properties for '{server_name}': {e}",
-            exc_info=True,
-        )
         return {
             "status": "error",
             "message": f"Unexpected error reading properties: {e}",
@@ -626,86 +424,53 @@ def read_server_properties(
 
 
 def validate_server_property_value(property_name: str, value: str) -> Dict[str, str]:
-    """
-    Validates the value for common server properties based on expected format or range.
-
-    Note: This provides basic client-side or API-level validation. The core
-    `modify_server_properties` should ideally rely on the server itself for
-    ultimate validation, but this can catch common errors early.
-
-    Args:
-        property_name: The name of the property being validated (e.g., "server-port").
-        value: The string value to validate.
-
-    Returns:
-        `{"status": "success"}` if validation passes, or
-        `{"status": "error", "message": "Validation error description..."}` if it fails.
-    """
     logger.debug(
-        f"Validating server property value: Property='{property_name}', Value='{value}'"
+        f"API: Validating server property: '{property_name}', Value: '{value}'"
     )
-
-    # Allow empty values for some properties? Handle None input.
     if value is None:
         value = ""
-
-    # Example Validations (Expand as needed)
     if property_name == "server-name":
-        # Minecraft allows most characters, but ';' can break parsing sometimes. Limit length?
         if ";" in value:
-            msg = f"Value for '{property_name}' cannot contain semicolons."
-            logger.warning(msg + f" Value: '{value}'")
-            return {"status": "error", "message": msg}
-        if len(value) > 100:  # Arbitrary length limit example
-            msg = f"Value for '{property_name}' is excessively long (max 100 chars)."
-            logger.warning(msg + f" Value: '{value[:50]}...'")
-            return {"status": "error", "message": msg}
-
+            return {
+                "status": "error",
+                "message": "server-name cannot contain semicolons.",
+            }
+        if len(value) > 100:
+            return {
+                "status": "error",
+                "message": "server-name is too long (max 100 chars).",
+            }
     elif property_name == "level-name":
-        # Official recommendation: Avoid special characters that might cause issues on file systems.
-        # Let's enforce alphanumeric, underscore, hyphen.
         if not re.fullmatch(r"[a-zA-Z0-9_\-]+", value):
-            msg = f"Invalid value for '{property_name}'. Only use letters, numbers, underscore (_), and hyphen (-)."
-            logger.warning(msg + f" Value: '{value}'")
-            return {"status": "error", "message": msg}
-        if len(value) > 80:  # Arbitrary length limit
-            msg = f"Value for '{property_name}' is too long (max 80 chars)."
-            logger.warning(msg + f" Value: '{value[:50]}...'")
-            return {"status": "error", "message": msg}
-
+            return {
+                "status": "error",
+                "message": "level-name: use letters, numbers, underscore, hyphen.",
+            }
+        if len(value) > 80:
+            return {
+                "status": "error",
+                "message": "level-name is too long (max 80 chars).",
+            }
     elif property_name in ("server-port", "server-portv6"):
         try:
-            port_num = int(value)
-            # Standard port range, avoiding privileged ports (<1024)
-            if not (1024 <= port_num <= 65535):
-                raise ValueError("Port number out of valid range.")
+            port = int(value)
+            if not (1024 <= port <= 65535):
+                raise ValueError()
         except (ValueError, TypeError):
-            msg = f"Invalid value for '{property_name}'. Must be a number between 1024 and 65535."
-            logger.warning(msg + f" Value: '{value}'")
-            return {"status": "error", "message": msg}
-
-    elif property_name in ("max-players", "view-distance", "tick-distance"):
+            return {
+                "status": "error",
+                "message": f"{property_name}: must be a number 1024-65535.",
+            }
+    elif property_name == "max-players":
         try:
-            num_val = int(value)
-            if property_name == "max-players" and num_val < 1:
-                raise ValueError("Must be >= 1")
-            if property_name == "view-distance" and num_val < 5:
-                raise ValueError("Must be >= 5")
-            if property_name == "tick-distance" and not (4 <= num_val <= 12):
-                raise ValueError("Must be between 4-12")
+            if int(value) < 1:
+                raise ValueError()
         except (ValueError, TypeError):
-            range_msg = "a positive number"
-            if property_name == "view-distance":
-                range_msg = "a number >= 5"
-            if property_name == "tick-distance":
-                range_msg = "a number between 4 and 12"
-            msg = f"Invalid value for '{property_name}'. Must be {range_msg}."
-            logger.warning(msg + f" Value: '{value}'")
-            return {"status": "error", "message": msg}
+            return {
+                "status": "error",
+                "message": "max-players: must be a positive number.",
+            }
 
-    logger.debug(
-        f"Validation successful for Property='{property_name}', Value='{value}'"
-    )
     return {"status": "success"}
 
 
@@ -713,205 +478,227 @@ def modify_server_properties(
     server_name: str,
     properties_to_update: Dict[str, str],
     base_dir: Optional[str] = None,
+    restart_after_modify: bool = True,
 ) -> Dict[str, str]:
-    """
-    Modifies one or more properties in the server's `server.properties` file.
-
-    Performs basic validation on values before attempting to write.
-
-    Args:
-        server_name: The name of the server.
-        properties_to_update: A dictionary where keys are property names and values
-                              are the new string values to set.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-
-    Returns:
-        A dictionary: `{"status": "success", "message": ...}` or `{"status": "error", "message": ...}`.
-        If multiple validation errors occur, only the first one encountered is returned.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        TypeError: If `properties_to_update` is not a dictionary.
-        FileOperationError: If `base_dir` cannot be determined or core modification fails.
-    """
     if not server_name:
-        raise InvalidServerNameError("Server name cannot be empty.")
+        raise InvalidServerNameError("Server name required.")
     if not isinstance(properties_to_update, dict):
-        raise TypeError("properties_to_update must be a dictionary.")
+        raise TypeError("Properties must be a dict.")
     if not properties_to_update:
-        logger.warning(f"No properties provided to modify for server '{server_name}'.")
-        return {
-            "status": "success",
-            "message": "No properties specified for modification.",
-        }
+        return {"status": "success", "message": "No properties specified."}
 
-    logger.debug(
-        f"Modifying server properties for server '{server_name}': {list(properties_to_update.keys())}"
+    logger.info(
+        f"API: Modifying properties for '{server_name}'. Restart: {restart_after_modify}"
     )
-
     try:
         effective_base_dir = get_base_dir(base_dir)
         server_properties_path = os.path.join(
             effective_base_dir, server_name, "server.properties"
         )
-
         if not os.path.isfile(server_properties_path):
             raise FileNotFoundError(
-                f"server.properties file not found at: {server_properties_path}"
+                f"server.properties not found: {server_properties_path}"
             )
 
-        # --- Validate all properties ---
-        validation_errors = {}
-        validated_properties = {}
-        for prop_name, prop_value in properties_to_update.items():
-            # Ensure value is string for validation and writing
-            prop_value_str = str(prop_value) if prop_value is not None else ""
-            validation_result = validate_server_property_value(
-                prop_name, prop_value_str
+        validated_props = {}
+        for name, val_str in properties_to_update.items():
+            val_res = validate_server_property_value(
+                name, str(val_str) if val_str is not None else ""
             )
-            if validation_result.get("status") == "error":
-                validation_errors[prop_name] = validation_result.get("message")
-            else:
-                validated_properties[prop_name] = (
-                    prop_value_str  # Store validated string value
+            if val_res.get("status") == "error":
+                return {
+                    "status": "error",
+                    "message": f"Validation failed for '{name}': {val_res.get('message')}",
+                }
+            validated_props[name] = str(val_str) if val_str is not None else ""
+
+        with _server_stop_start_manager(
+            server_name,
+            effective_base_dir,
+            stop_start_flag=restart_after_modify,
+            restart_on_success_only=True,
+        ):
+            for prop_name, prop_value in validated_props.items():
+                core_server_base.modify_server_properties(
+                    server_properties_path, prop_name, prop_value
                 )
 
-        if validation_errors:
-            error_msg = "Validation failed for one or more properties: " + "; ".join(
-                [f"{k}: {v}" for k, v in validation_errors.items()]
+        message = "Server properties updated."
+        if restart_after_modify:
+            message += (
+                " Server restart handled (if it was running and properties changed)."
             )
-            logger.error(error_msg)
-            return {"status": "error", "message": error_msg}
-
-        # --- Apply validated properties ---
-        for prop_name, prop_value in validated_properties.items():
-            logger.info(f"Applying change: {prop_name}={prop_value}")
-            # Core function raises FileOperationError, InvalidInputError
-            server_base.modify_server_properties(
-                server_properties_path, prop_name, prop_value
+        else:
+            message += (
+                " Manual server restart may be needed for changes to take effect."
             )
+        return {"status": "success", "message": message}
 
-        logger.info(f"Successfully modified properties for server '{server_name}'.")
-        return {
-            "status": "success",
-            "message": "Server properties updated successfully.",
-        }
-
-    except (FileNotFoundError, FileOperationError, InvalidInputError) as e:
+    except (
+        FileNotFoundError,
+        FileOperationError,
+        InvalidInputError,
+        InvalidServerNameError,
+    ) as e:
         logger.error(
-            f"Failed to modify server properties for '{server_name}': {e}",
-            exc_info=True,
+            f"API: Failed to modify properties for '{server_name}': {e}", exc_info=True
         )
         return {"status": "error", "message": f"Failed to modify properties: {e}"}
     except Exception as e:
         logger.error(
-            f"Unexpected error modifying server properties for '{server_name}': {e}",
+            f"API: Unexpected error modifying properties for '{server_name}': {e}",
             exc_info=True,
         )
-        return {
-            "status": "error",
-            "message": f"Unexpected error modifying properties: {e}",
-        }
+        return {"status": "error", "message": f"Unexpected error: {e}"}
+
+
+# --- INSTALL/UPDATE FUNCTIONS ---
 
 
 def download_and_install_server(
     server_name: str,
     base_dir: Optional[str] = None,
     target_version: str = "LATEST",
-    in_update: bool = False,
+    is_update: bool = False,
 ) -> Dict[str, Any]:
     """
-    Downloads the specified Bedrock server version and installs/updates it.
-
-    Orchestrates calls to core downloader and server installation functions.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        target_version: Version to download ("LATEST", "PREVIEW", or specific "1.x.y.z").
-        in_update: True if updating an existing server, False for a fresh install.
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "version": str, "message": str} on success.
-        - {"status": "error", "message": str} on failure.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
+    API: Downloads the specified Bedrock server version and installs/updates it.
+    This function orchestrates the entire process including stop/start for updates.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
-
-    action = "Updating" if in_update else "Installing"
-    logger.debug(
-        f"Starting server download and {action.lower()} process for '{server_name}', target version '{target_version}'."
+    action = "Updating" if is_update else "Installing"
+    logger.info(
+        f"API: Starting server {action.lower()} process for '{server_name}', target version '{target_version}'."
     )
+
+    # Define app_config_dir early for use in error handlers if needed
+    app_config_dir = settings._config_dir
+    if not app_config_dir:
+        # This is a critical configuration error
+        logger.critical(
+            "API: Application configuration directory (_config_dir) not set in settings. Cannot proceed."
+        )
+        return {
+            "status": "error",
+            "message": "Application configuration error: _config_dir not set.",
+        }
 
     try:
         effective_base_dir = get_base_dir(base_dir)
         server_dir = os.path.join(effective_base_dir, server_name)
 
-        # 1. Download phase (core function handles checks, returns paths)
-        logger.info("Step 1: Downloading server files...")
-        # download_bedrock_server raises: InternetConnectivityError, DirectoryError, DownloadExtractError, FileOperationError
-        actual_version, zip_file_path, _ = downloader.download_bedrock_server(
-            server_dir=server_dir,  # Pass server dir (it ensures it exists)
-            target_version=target_version,
+        # --- 1. Download Phase ---
+        logger.info("API: Step 1 - Downloading server software...")
+        actual_version, zip_file_path, _ = core_downloader.download_bedrock_server(
+            server_dir=server_dir, target_version=target_version
         )
         logger.debug(
-            f"Download complete. Version: {actual_version}, ZIP: {zip_file_path}"
+            f"API: Download complete. Version: {actual_version}, ZIP: {zip_file_path}"
         )
 
-        # 2. Installation phase (core function handles extraction, permissions, version config)
-        logger.info(f"Step 2: {action} server files...")
-        # install_server raises: InstallUpdateError, FileOperationError, BackupWorldError, RestoreError, etc.
-        server_base.install_server(
-            server_name=server_name,
-            base_dir=effective_base_dir,
-            target_version=actual_version,
-            zip_file_path=zip_file_path,
-            server_dir=server_dir,
-            is_update=in_update,
-        )
+        # --- 2. Orchestrate Stop, Backup (if update), File Setup, Start ---
+        with _server_stop_start_manager(
+            server_name,
+            effective_base_dir,
+            stop_start_flag=is_update,
+            restart_on_success_only=True,  # Only restart if backup & setup are fine
+        ):
+            if is_update:
+                logger.info(
+                    f"API: Step 2a - Backing up server '{server_name}' before update..."
+                )
+                core_backup.backup_all_server_data(server_name, effective_base_dir)
+                logger.info(f"API: Pre-update backup for '{server_name}' successful.")
+
+            logger.info(
+                f"API: Step 2b - Setting up server files from '{os.path.basename(zip_file_path)}'..."
+            )
+            core_server_base.setup_server_files(
+                zip_file_path=zip_file_path, server_dir=server_dir, is_update=is_update
+            )
+            logger.info("API: Server file setup successful.")
+
+            # --- 3. Finalizing Configuration ---
+            logger.info(
+                f"API: Step 3 - Writing version '{actual_version}' and status for '{server_name}'."
+            )
+            core_server_base._write_version_config(
+                server_name, actual_version, config_dir=app_config_dir
+            )
+
+            if not is_update:
+                core_server_base.manage_server_config(
+                    server_name,
+                    "status",
+                    "write",
+                    "INSTALLED",
+                    config_dir=app_config_dir,
+                )
+            else:  # For updates, server is currently stopped by context manager.
+                # If it was running, context manager's 'finally' will restart it.
+                # core_server_base.start_server called by API start will set status to RUNNING.
+                # If it wasn't running, it should remain STOPPED.
+                core_server_base.manage_server_config(
+                    server_name, "status", "write", "STOPPED", config_dir=app_config_dir
+                )
+
+        # Message after context manager, reflecting potential restart
+        final_message = f"Server '{server_name}' {action.lower()} to version {actual_version} successful."
+        if is_update:
+            final_message += " Server restart handled if it was previously running."
+
         logger.info(
-            f"Server {action.lower()} completed successfully for version {actual_version}."
+            f"API: Server {action.lower()} for '{server_name}' (v{actual_version}) orchestrated successfully."
         )
-
         return {
             "status": "success",
             "version": actual_version,
-            "message": f"Server '{server_name}' {action.lower()} successful (Version: {actual_version}).",
+            "message": final_message,
         }
 
-    # Catch specific errors from download/install phases
     except (
-        DownloadExtractError,
-        InternetConnectivityError,
+        core_downloader.DownloadExtractError,
+        core_downloader.InternetConnectivityError,
         InstallUpdateError,
         DirectoryError,
         FileOperationError,
         BackupWorldError,
-        RestoreError,
+        MissingArgumentError,
+        InvalidServerNameError,
     ) as e:
         logger.error(
-            f"Server download/install process failed for '{server_name}': {e}",
+            f"API: Server {action.lower()} process failed for '{server_name}': {e}",
             exc_info=True,
         )
+        try:
+            if app_config_dir:  # Check if app_config_dir was resolved
+                core_server_base.manage_server_config(
+                    server_name, "status", "write", "ERROR", config_dir=app_config_dir
+                )
+        except Exception as e_cfg:
+            logger.error(
+                f"API: Additionally failed to set error status for '{server_name}': {e_cfg}"
+            )
         return {"status": "error", "message": f"Server {action.lower()} failed: {e}"}
-    except FileOperationError as e:  # Catch error from get_base_dir
-        logger.error(
-            f"Configuration error preventing server download/install for '{server_name}': {e}",
+    except Exception as e:  # Catch-all for truly unexpected issues
+        logger.critical(
+            f"API: CRITICAL UNEXPECTED error during server {action.lower()} for '{server_name}': {e}",
             exc_info=True,
         )
-        return {"status": "error", "message": f"Configuration error: {e}"}
-    except Exception as e:
-        logger.error(
-            f"Unexpected error during server download/install for '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {"status": "error", "message": f"An unexpected error occurred: {e}"}
+        try:
+            if app_config_dir:
+                core_server_base.manage_server_config(
+                    server_name, "status", "write", "ERROR", config_dir=app_config_dir
+                )
+        except Exception as e_cfg:
+            logger.error(
+                f"API: Additionally failed to set error status for '{server_name}': {e_cfg}"
+            )
+        return {
+            "status": "error",
+            "message": f"An critical unexpected error occurred: {e}",
+        }
 
 
 def install_new_server(
@@ -920,233 +707,169 @@ def install_new_server(
     base_dir: Optional[str] = None,
     config_dir: Optional[str] = None,
 ) -> Dict[str, str]:
-    """
-    Installs a completely new Bedrock server instance.
-
-    Validates name, checks for existing server, writes initial config,
-    downloads/installs files, and sets initial status.
-
-    Args:
-        server_name: The desired name for the new server.
-        target_version: Version to install ("LATEST", "PREVIEW", or specific "1.x.y.z").
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        config_dir: Optional. Base directory for server configs. Uses default if None.
-
-    Returns:
-        A dictionary indicating the outcome: `{"status": "success", "server_name": str, "message": ...}`
-        or `{"status": "error", "message": str}`.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        FileOperationError: If `base_dir` cannot be determined.
-    """
     if not server_name:
         raise MissingArgumentError("Server name cannot be empty.")
-
-    logger.debug(
-        f"Starting installation process for new server '{server_name}', target version '{target_version}'."
+    logger.info(
+        f"API: Installing new server '{server_name}', target version '{target_version}'."
     )
+
+    # Define app_config_dir early for consistent use
+    effective_app_config_dir = (
+        config_dir if config_dir is not None else settings._config_dir
+    )
+    if not effective_app_config_dir:
+        logger.critical(
+            "API: Application configuration directory (_config_dir) not set. Cannot install new server."
+        )
+        return {
+            "status": "error",
+            "message": "Application configuration error: _config_dir not set.",
+        }
 
     try:
         effective_base_dir = get_base_dir(base_dir)
 
-        # --- 1. Validate Name Format ---
-        validation_result = validate_server_name_format(server_name)  # Returns dict
+        validation_result = validate_server_name_format(server_name)
         if validation_result.get("status") == "error":
-            logger.error(
-                f"Invalid server name format for '{server_name}': {validation_result.get('message')}"
-            )
-            return validation_result  # Return the validation error dict
+            return validation_result
 
-        # --- 2. Check if Server Already Exists ---
-        server_dir = os.path.join(effective_base_dir, server_name)
-        if os.path.exists(server_dir):
-            # Check if it's just an empty dir or actually contains files? For now, any existence is error.
-            error_msg = (
-                f"Cannot install new server: Directory '{server_dir}' already exists."
-            )
-            logger.error(error_msg)
-            return {"status": "error", "message": error_msg}
+        server_dir_check = os.path.join(effective_base_dir, server_name)
+        if os.path.exists(server_dir_check):
+            return {
+                "status": "error",
+                "message": f"Directory '{server_dir_check}' already exists.",
+            }
 
-        # --- 3. Write Initial Config (Name, Target Version) ---
-        logger.debug("Writing initial server configuration...")
-        config_results = []
-        config_results.append(
-            write_server_config(server_name, "server_name", server_name, config_dir)
-        )
-        config_results.append(
-            write_server_config(
-                server_name, "target_version", target_version, config_dir
+        # Write initial config (name, target version, initial status)
+        # Use api_write_server_config as it returns dicts, easy to check status
+        init_configs = {
+            "server_name": server_name,
+            "target_version": target_version,
+            "status": "INSTALLING",  # Initial status before download
+        }
+        for key, value in init_configs.items():
+            cfg_res = api_write_server_config(
+                server_name, key, value, config_dir=effective_app_config_dir
             )
-        )
-        # Check if any config write failed
-        for result in config_results:
-            if result.get("status") == "error":
+            if cfg_res.get("status") == "error":
                 logger.error(
-                    f"Failed to write initial configuration for server '{server_name}'. Error: {result.get('message')}"
+                    f"API: Failed to write initial config '{key}' for '{server_name}': {cfg_res.get('message')}"
                 )
-                return result  # Return the first config write error
+                return {
+                    "status": "error",
+                    "message": f"Initial config write failed for '{key}': {cfg_res.get('message')}",
+                }
 
-        # --- 4. Download and Install ---
-        logger.debug(
-            f"Proceeding with download and installation for server '{server_name}'..."
-        )
-        # Use the API function which returns dict
+        # Call the main orchestrator for download and file setup
+        # is_update=False means _server_stop_start_manager will effectively be a no-op for stop/start
         install_result = download_and_install_server(
             server_name=server_name,
             base_dir=effective_base_dir,
             target_version=target_version,
-            in_update=False,  # Explicitly False for new install
+            is_update=False,
         )
-        if install_result.get("status") == "error":
+
+        # download_and_install_server will set status to "INSTALLED" on success for new install.
+        return install_result  # Return the result from the main orchestrator
+
+    except (MissingArgumentError, FileOperationError, InvalidServerNameError) as e:
+        logger.error(
+            f"API: Setup error for new server '{server_name}': {e}", exc_info=True
+        )
+        # Attempt to set server status to ERROR in config
+        try:
+            if effective_app_config_dir:
+                core_server_base.manage_server_config(
+                    server_name,
+                    "status",
+                    "write",
+                    "ERROR",
+                    config_dir=effective_app_config_dir,
+                )
+        except Exception as e_cfg:
             logger.error(
-                f"Download/installation failed for new server '{server_name}'. Error: {install_result.get('message')}"
+                f"API: Additionally failed to set error status for '{server_name}': {e_cfg}"
             )
-            return install_result  # Return the install error
-
-        installed_version = install_result.get(
-            "version", "UNKNOWN"
-        )  # Get version from successful result
-
-        # --- 5. Write Final Status ---
-        logger.debug("Writing final status ('INSTALLED') to server configuration...")
-        status_result = write_server_config(
-            server_name, "status", "INSTALLED", config_dir
-        )
-        if status_result.get("status") == "error":
-            # Installation succeeded but status write failed - log warning, but return success for install itself?
-            logger.warning(
-                f"Server '{server_name}' installed successfully (Version: {installed_version}), but failed to write final status to config: {status_result.get('message')}"
-            )
-            # Let's return success but mention the status issue
-            return {
-                "status": "success",
-                "server_name": server_name,
-                "message": f"Server '{server_name}' installed (Version: {installed_version}), but status update failed.",
-            }
-
-        logger.info(
-            f"New server '{server_name}' (Version: {installed_version}) installed successfully."
-        )
-        return {
-            "status": "success",
-            "server_name": server_name,
-            "version": installed_version,
-            "message": f"Server '{server_name}' installed successfully (Version: {installed_version}).",
-        }
-
-    except FileOperationError as e:  # Catch error from get_base_dir
-        logger.error(
-            f"Configuration error preventing server installation for '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {"status": "error", "message": f"Configuration error: {e}"}
+        return {"status": "error", "message": f"Setup error for new server: {e}"}
     except Exception as e:
-        # Catch unexpected errors during orchestration
-        logger.error(
-            f"Unexpected error during new server installation for '{server_name}': {e}",
+        logger.critical(
+            f"API: CRITICAL UNEXPECTED error installing new server '{server_name}': {e}",
             exc_info=True,
         )
+        try:
+            if effective_app_config_dir:
+                core_server_base.manage_server_config(
+                    server_name,
+                    "status",
+                    "write",
+                    "ERROR",
+                    config_dir=effective_app_config_dir,
+                )
+        except Exception as e_cfg:
+            logger.error(
+                f"API: Additionally failed to set error status for '{server_name}': {e_cfg}"
+            )
         return {
             "status": "error",
-            "message": f"Unexpected error installing server: {e}",
+            "message": f"An critical unexpected error occurred installing new server: {e}",
         }
 
 
 def update_server(
-    server_name: str,
-    base_dir: Optional[str] = None,
-    send_message: bool = True,
+    server_name: str, base_dir: Optional[str] = None, send_message: bool = True
 ) -> Dict[str, Any]:
-    """
-    Updates an existing Bedrock server to the target version specified in its config.
-
-    Checks if an update is needed, handles download/installation, and optionally
-    sends an in-game warning message if the server is running.
-
-    Args:
-        server_name: The name of the server to update.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        send_message: If True, attempt to send "say Checking for updates..." message
-                      to the server if it's running.
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "updated": bool, "new_version": Optional[str], "message": str}
-        - {"status": "error", "message": str}
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined or essential config cannot be read.
-    """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
+    logger.info(f"API: Updating server '{server_name}'. Send message: {send_message}")
 
-    logger.debug(
-        f"Starting update check process for server '{server_name}'. Send message: {send_message}"
-    )
+    # Define app_config_dir early
+    effective_app_config_dir = settings._config_dir
+    if not effective_app_config_dir:
+        logger.critical(
+            "API: Application configuration directory (_config_dir) not set. Cannot update server."
+        )
+        return {
+            "status": "error",
+            "message": "Application configuration error: _config_dir not set.",
+        }
 
     try:
         effective_base_dir = get_base_dir(base_dir)
 
-        # --- Check if server is running and send message (optional) ---
-        if send_message:
-            try:
-                if system_base.is_server_running(server_name, effective_base_dir):
-                    logger.info(
-                        f"Server '{server_name}' is running. Sending update check notification..."
-                    )
-                    # Use API send_command which returns dict
-                    cmd_result = send_command(
-                        server_name,
-                        "say Checking for server updates...",
-                        effective_base_dir,
-                    )
-                    if cmd_result.get("status") == "error":
-                        # Log warning but don't abort update if message fails
-                        logger.warning(
-                            f"Failed to send update notification message to server '{server_name}': {cmd_result.get('message')}"
-                        )
-                    else:
-                        logger.debug("Update notification sent.")
-                else:
-                    logger.debug(
-                        f"Server '{server_name}' is not running. Skipping update notification."
-                    )
-            except Exception as e:
-                # Catch any error during running check or message sending, log warning and continue
+        if send_message and core_server_base.check_if_server_is_running(
+            server_name
+        ):  # Pass base_dir if core func needs it
+            logger.info(
+                f"API: Server '{server_name}' running. Sending update check notification..."
+            )
+            cmd_res = api_send_command(
+                server_name, "say Checking for server updates..."
+            )
+            if cmd_res.get("status") == "error":
                 logger.warning(
-                    f"Could not send update notification to server '{server_name}': {e}",
-                    exc_info=True,
+                    f"API: Failed to send update notification to '{server_name}': {cmd_res.get('message')}"
                 )
 
-        # --- Get Installed and Target Versions ---
-        logger.debug("Retrieving installed and target versions...")
-        installed_version = server_base.get_installed_version(server_name)
-        target_version = server_base.manage_server_config(
-            server_name, "target_version", "read"
+        installed_version = core_server_base.get_installed_version(
+            server_name, config_dir=effective_app_config_dir
+        )
+        target_version_cfg = core_server_base.manage_server_config(
+            server_name, "target_version", "read", config_dir=effective_app_config_dir
         )
 
-        if installed_version == "UNKNOWN":
-            logger.warning(
-                f"Cannot determine installed version for server '{server_name}'. Assuming update is needed."
-            )
-            # Proceed, but download_and_install will handle actual version check logic if target is LATEST/PREVIEW
-        if target_version is None:
-            logger.warning(
-                f"Target version not found in config for server '{server_name}'. Defaulting to 'LATEST'."
-            )
-            target_version = "LATEST"  # Default behavior if not set
-
-        logger.debug(
-            f"Server '{server_name}': Installed Version='{installed_version}', Target Version='{target_version}'"
+        target_version_to_use = (
+            str(target_version_cfg) if target_version_cfg is not None else "LATEST"
         )
+        if target_version_cfg is None:
+            logger.warning(
+                f"API: Target version not set for '{server_name}', defaulting to 'LATEST'."
+            )
 
-        # --- Check if Update is Needed ---
-        if server_base.no_update_needed(server_name, installed_version, target_version):
+        if core_server_base.no_update_needed(
+            server_name, installed_version, target_version_to_use
+        ):
             logger.info(
-                f"Server '{server_name}' is already up-to-date (Version: {installed_version})."
+                f"API: Server '{server_name}' (v{installed_version}) is already up-to-date with target '{target_version_to_use}'."
             )
             return {
                 "status": "success",
@@ -1155,55 +878,69 @@ def update_server(
                 "message": "Server is already up-to-date.",
             }
 
-        # --- Perform Download and Installation (as update) ---
-        logger.info(f"Proceeding with update attempt for server '{server_name}'...")
+        # Call the main orchestrator for download and file setup, with is_update=True
         update_result = download_and_install_server(
             server_name=server_name,
             base_dir=effective_base_dir,
-            target_version=target_version,
-            in_update=True,  # Explicitly True for update
+            target_version=target_version_to_use,
+            is_update=True,
         )
 
-        # --- Process Result ---
+        # download_and_install_server's message already reflects success and version.
+        # We just need to adjust the 'updated' flag logic if needed, but it's better if
+        # download_and_install_server's response is comprehensive.
         if update_result.get("status") == "success":
-            new_version = update_result.get("version", "UNKNOWN")
-            updated_flag = (
-                installed_version != new_version
-            )  # Set flag based on actual version change
-            message = f"Server '{server_name}' update process completed. "
-            if updated_flag:
-                message += f"New version: {new_version}."
-            else:
-                message += f"Server already at target version ({installed_version})."
-            logger.info(message)
+            new_actual_version = update_result.get("version", "UNKNOWN")
             return {
                 "status": "success",
-                "updated": updated_flag,
-                "new_version": new_version,
-                "message": message,
+                "updated": installed_version
+                != new_actual_version,  # Compare old installed with new actual
+                "new_version": new_actual_version,
+                "message": update_result.get(
+                    "message",
+                    f"Server '{server_name}' update process completed. New version: {new_actual_version}.",
+                ),
             }
         else:
-            # Update failed during download/install phase
-            logger.error(
-                f"Update failed for server '{server_name}'. Error: {update_result.get('message')}"
-            )
-            return (
-                update_result  # Return the error dict from download_and_install_server
-            )
+            return update_result
 
-    except (InvalidServerNameError, MissingArgumentError) as e:
-        # Re-raise input validation errors
-        raise
-    except FileOperationError as e:  # Catch error from get_base_dir or core functions
+    except (FileOperationError, InvalidServerNameError, MissingArgumentError) as e:
         logger.error(
-            f"Configuration or File error preventing server update for '{server_name}': {e}",
-            exc_info=True,
+            f"API: Setup error for server update '{server_name}': {e}", exc_info=True
         )
-        return {"status": "error", "message": f"Configuration/File error: {e}"}
+        try:
+            if effective_app_config_dir:
+                core_server_base.manage_server_config(
+                    server_name,
+                    "status",
+                    "write",
+                    "ERROR",
+                    config_dir=effective_app_config_dir,
+                )
+        except Exception as e_cfg:
+            logger.error(
+                f"API: Additionally failed to set error status for '{server_name}': {e_cfg}"
+            )
+        return {"status": "error", "message": f"Setup error for update: {e}"}
     except Exception as e:
-        # Catch unexpected errors during orchestration
-        logger.error(
-            f"Unexpected error during update process for server '{server_name}': {e}",
+        logger.critical(
+            f"API: CRITICAL UNEXPECTED error updating server '{server_name}': {e}",
             exc_info=True,
         )
-        return {"status": "error", "message": f"Unexpected error during update: {e}"}
+        try:
+            if effective_app_config_dir:
+                core_server_base.manage_server_config(
+                    server_name,
+                    "status",
+                    "write",
+                    "ERROR",
+                    config_dir=effective_app_config_dir,
+                )
+        except Exception as e_cfg:
+            logger.error(
+                f"API: Additionally failed to set error status for '{server_name}': {e_cfg}"
+            )
+        return {
+            "status": "error",
+            "message": f"An critical unexpected error occurred updating server: {e}",
+        }

--- a/src/bedrock_server_manager/api/system.py
+++ b/src/bedrock_server_manager/api/system.py
@@ -13,7 +13,7 @@ import platform
 from typing import Dict, Optional, Any
 
 # Local imports
-from bedrock_server_manager.api.server_install_config import write_server_config
+from bedrock_server_manager.api.server import write_server_config
 from bedrock_server_manager.core.system import (
     base as system_base,
     linux as system_linux,

--- a/src/bedrock_server_manager/api/utils.py
+++ b/src/bedrock_server_manager/api/utils.py
@@ -10,8 +10,6 @@ from bedrock_server_manager.core.system import base as system_base
 from bedrock_server_manager.core.server import server as core_server_base
 from bedrock_server_manager.api.server import (
     start_server as api_start_server,
-)  # For context manager
-from bedrock_server_manager.api.server import (
     stop_server as api_stop_server,
 )  # For context manager
 from bedrock_server_manager.utils.general import (
@@ -456,14 +454,30 @@ def get_system_and_app_info() -> Dict[str, Any]:
 
 
 @contextmanager
-def _server_stop_start_manager(server_name: str, base_dir: str, stop_start_flag: bool):
+def _server_stop_start_manager(
+    server_name: str,
+    base_dir: str,
+    stop_start_flag: bool,
+    restart_on_success_only: bool = False,
+):
     """
     Context manager to handle stopping a server before an operation and
     restarting it afterward if it was running.
+
+    Args:
+        server_name: The name of the server.
+        base_dir: Base directory for the server.
+        stop_start_flag: If True, perform stop/start.
+        restart_on_success_only: If True, only attempt restart if the managed
+                                 block ('yield') completed without exceptions.
     """
     was_running = False
-    error_during_operation = False
+    operation_succeeded = True
+
     if not stop_start_flag:
+        logger.debug(
+            f"Context Mgr: Stop/Start not flagged for '{server_name}'. Skipping."
+        )
         yield
         return
 
@@ -471,44 +485,59 @@ def _server_stop_start_manager(server_name: str, base_dir: str, stop_start_flag:
         logger.debug(
             f"Context Mgr: Checking status for '{server_name}' (Stop/Start: {stop_start_flag})"
         )
-        # Use core_server_base.check_if_server_is_running for direct check
-        if core_server_base.check_if_server_is_running(
-            server_name
-        ):  # Pass base_dir if check_if_server_is_running needs it
+        if core_server_base.check_if_server_is_running(server_name):
             was_running = True
             logger.info(f"Context Mgr: Server '{server_name}' is running. Stopping...")
-            # Use API stop function as it returns dict and handles layers
             stop_result = api_stop_server(server_name, base_dir)
             if stop_result.get("status") == "error":
                 raise FileOperationError(
-                    f"Context Mgr: Failed to stop server '{server_name}': {stop_result.get('message')}"
+                    f"Context Mgr: Failed to stop server '{server_name}' for operation: {stop_result.get('message')}"
                 )
             logger.info(f"Context Mgr: Server '{server_name}' stopped.")
         else:
-            logger.debug(f"Context Mgr: Server '{server_name}' is not running.")
+            logger.debug(
+                f"Context Mgr: Server '{server_name}' is not running. No stop needed."
+            )
 
         yield
 
     except Exception:
-        error_during_operation = True
+        operation_succeeded = False
+        logger.error(
+            f"Context Mgr: Exception occurred during managed operation for '{server_name}'."
+        )
         raise
     finally:
         if stop_start_flag and was_running:
-            if error_during_operation:
+            should_restart_based_on_success_flag = True
+            if restart_on_success_only and not operation_succeeded:  # Check the flag
+                should_restart_based_on_success_flag = False
                 logger.warning(
-                    f"Context Mgr: Attempting to restart '{server_name}' despite operation error."
+                    f"Context Mgr: Operation for '{server_name}' failed, and restart_on_success_only is True. Skipping restart."
                 )
-            else:
-                logger.info(f"Context Mgr: Restarting server '{server_name}'...")
 
-            start_result = api_start_server(server_name, base_dir)
-            if start_result.get("status") == "error":
-                logger.error(
-                    f"Context Mgr: Failed to restart '{server_name}': {start_result.get('message')}"
-                )
-                if not error_during_operation:
-                    raise FileOperationError(
-                        f"Operation successful, but failed to restart server: {start_result.get('message')}"
+            if should_restart_based_on_success_flag:
+                if (
+                    not operation_succeeded
+                ):  # Still attempt if restart_on_success_only is False
+                    logger.warning(
+                        f"Context Mgr: Attempting to restart '{server_name}' despite operation error (restart_on_success_only is False or operation succeeded)."
                     )
-            else:
-                logger.info(f"Context Mgr: Server '{server_name}' restart initiated.")
+                else:
+                    logger.info(f"Context Mgr: Restarting server '{server_name}'...")
+
+                start_result = api_start_server(server_name, base_dir, mode="detached")
+                if start_result.get("status") == "error":
+                    logger.error(
+                        f"Context Mgr: Failed to restart '{server_name}': {start_result.get('message')}"
+                    )
+                    if (
+                        operation_succeeded
+                    ):  # If main op was fine, this error is now primary
+                        raise FileOperationError(
+                            f"Operation successful, but failed to restart server '{server_name}': {start_result.get('message')}"
+                        )
+                else:
+                    logger.info(
+                        f"Context Mgr: Server '{server_name}' restart initiated."
+                    )

--- a/src/bedrock_server_manager/api/utils.py
+++ b/src/bedrock_server_manager/api/utils.py
@@ -8,8 +8,12 @@ from contextlib import contextmanager
 from bedrock_server_manager.config.settings import settings
 from bedrock_server_manager.core.system import base as system_base
 from bedrock_server_manager.core.server import server as core_server_base
-from bedrock_server_manager.api.server import start_server as api_start_server # For context manager
-from bedrock_server_manager.api.server import stop_server as api_stop_server   # For context manager
+from bedrock_server_manager.api.server import (
+    start_server as api_start_server,
+)  # For context manager
+from bedrock_server_manager.api.server import (
+    stop_server as api_stop_server,
+)  # For context manager
 from bedrock_server_manager.utils.general import (
     get_base_dir,
 )
@@ -464,19 +468,25 @@ def _server_stop_start_manager(server_name: str, base_dir: str, stop_start_flag:
         return
 
     try:
-        logger.debug(f"Context Mgr: Checking status for '{server_name}' (Stop/Start: {stop_start_flag})")
+        logger.debug(
+            f"Context Mgr: Checking status for '{server_name}' (Stop/Start: {stop_start_flag})"
+        )
         # Use core_server_base.check_if_server_is_running for direct check
-        if core_server_base.check_if_server_is_running(server_name): # Pass base_dir if check_if_server_is_running needs it
+        if core_server_base.check_if_server_is_running(
+            server_name
+        ):  # Pass base_dir if check_if_server_is_running needs it
             was_running = True
             logger.info(f"Context Mgr: Server '{server_name}' is running. Stopping...")
             # Use API stop function as it returns dict and handles layers
             stop_result = api_stop_server(server_name, base_dir)
             if stop_result.get("status") == "error":
-                raise FileOperationError(f"Context Mgr: Failed to stop server '{server_name}': {stop_result.get('message')}")
+                raise FileOperationError(
+                    f"Context Mgr: Failed to stop server '{server_name}': {stop_result.get('message')}"
+                )
             logger.info(f"Context Mgr: Server '{server_name}' stopped.")
         else:
             logger.debug(f"Context Mgr: Server '{server_name}' is not running.")
-        
+
         yield
 
     except Exception:
@@ -485,14 +495,20 @@ def _server_stop_start_manager(server_name: str, base_dir: str, stop_start_flag:
     finally:
         if stop_start_flag and was_running:
             if error_during_operation:
-                logger.warning(f"Context Mgr: Attempting to restart '{server_name}' despite operation error.")
+                logger.warning(
+                    f"Context Mgr: Attempting to restart '{server_name}' despite operation error."
+                )
             else:
                 logger.info(f"Context Mgr: Restarting server '{server_name}'...")
-            
+
             start_result = api_start_server(server_name, base_dir)
             if start_result.get("status") == "error":
-                logger.error(f"Context Mgr: Failed to restart '{server_name}': {start_result.get('message')}")
+                logger.error(
+                    f"Context Mgr: Failed to restart '{server_name}': {start_result.get('message')}"
+                )
                 if not error_during_operation:
-                    raise FileOperationError(f"Operation successful, but failed to restart server: {start_result.get('message')}")
+                    raise FileOperationError(
+                        f"Operation successful, but failed to restart server: {start_result.get('message')}"
+                    )
             else:
                 logger.info(f"Context Mgr: Server '{server_name}' restart initiated.")

--- a/src/bedrock_server_manager/api/world.py
+++ b/src/bedrock_server_manager/api/world.py
@@ -15,7 +15,7 @@ from bedrock_server_manager.error import (
     FileOperationError,
     DirectoryError,
     BackupWorldError,
-    RestoreError,     
+    RestoreError,
     DownloadExtractError,
     MissingArgumentError,
     FileNotFoundError,
@@ -40,15 +40,27 @@ def get_world_name(server_name: str, base_dir: Optional[str] = None) -> Dict[str
     logger.debug(f"API: Attempting to get world name for server '{server_name}'...")
     try:
         effective_base_dir = get_base_dir(base_dir)
-        world_name_str = core_server_base.get_world_name(server_name, effective_base_dir)
-        logger.info(f"API: Retrieved world name for '{server_name}': '{world_name_str}'")
+        world_name_str = core_server_base.get_world_name(
+            server_name, effective_base_dir
+        )
+        logger.info(
+            f"API: Retrieved world name for '{server_name}': '{world_name_str}'"
+        )
         return {"status": "success", "world_name": world_name_str}
     except (FileOperationError, InvalidServerNameError) as e:
-        logger.error(f"API: Failed to get world name for '{server_name}': {e}", exc_info=True)
+        logger.error(
+            f"API: Failed to get world name for '{server_name}': {e}", exc_info=True
+        )
         return {"status": "error", "message": f"Failed to get world name: {e}"}
     except Exception as e:
-        logger.error(f"API: Unexpected error getting world name for '{server_name}': {e}", exc_info=True)
-        return {"status": "error", "message": f"Unexpected error getting world name: {e}"}
+        logger.error(
+            f"API: Unexpected error getting world name for '{server_name}': {e}",
+            exc_info=True,
+        )
+        return {
+            "status": "error",
+            "message": f"Unexpected error getting world name: {e}",
+        }
 
 
 def export_world(
@@ -63,7 +75,9 @@ def export_world(
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
-    logger.info(f"API: Initiating world export for server '{server_name}' (Stop/Start: {stop_start_server})")
+    logger.info(
+        f"API: Initiating world export for server '{server_name}' (Stop/Start: {stop_start_server})"
+    )
 
     try:
         effective_base_dir = get_base_dir(base_dir)
@@ -73,39 +87,62 @@ def export_world(
         else:
             backup_base_dir = settings.get("BACKUP_DIR")
             if not backup_base_dir:
-                raise FileOperationError("BACKUP_DIR setting missing for default export directory.")
+                raise FileOperationError(
+                    "BACKUP_DIR setting missing for default export directory."
+                )
             effective_export_dir = os.path.join(backup_base_dir, server_name)
         os.makedirs(effective_export_dir, exist_ok=True)
 
         # Get world name directly from core
-        world_name_str = core_server_base.get_world_name(server_name, effective_base_dir)
-        world_path = os.path.join(effective_base_dir, server_name, "worlds", world_name_str)
+        world_name_str = core_server_base.get_world_name(
+            server_name, effective_base_dir
+        )
+        world_path = os.path.join(
+            effective_base_dir, server_name, "worlds", world_name_str
+        )
 
         if not os.path.isdir(world_path):
-            raise DirectoryError(f"World directory '{world_name_str}' not found at: {world_path}")
+            raise DirectoryError(
+                f"World directory '{world_name_str}' not found at: {world_path}"
+            )
 
         timestamp = get_timestamp()
         export_filename = f"{world_name_str}_export_{timestamp}.mcworld"
         export_file_path = os.path.join(effective_export_dir, export_filename)
 
-        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
-            logger.info(f"API: Exporting world '{world_name_str}' from '{world_path}' to '{export_file_path}'...")
+        with _server_stop_start_manager(
+            server_name, effective_base_dir, stop_start_server
+        ):
+            logger.info(
+                f"API: Exporting world '{world_name_str}' from '{world_path}' to '{export_file_path}'..."
+            )
             core_world.export_world(world_path, export_file_path)
-        
-        logger.info(f"API: World for server '{server_name}' exported to '{export_file_path}'.")
+
+        logger.info(
+            f"API: World for server '{server_name}' exported to '{export_file_path}'."
+        )
         return {
             "status": "success",
             "export_file": export_file_path,
             "message": f"World '{world_name_str}' exported successfully to {export_filename}.",
         }
-    except ( MissingArgumentError, InvalidServerNameError, FileOperationError, DirectoryError,
-             BackupWorldError,
-             AddonExtractError
-            ) as e:
-        logger.error(f"API: Failed to export world for '{server_name}': {e}", exc_info=True)
+    except (
+        MissingArgumentError,
+        InvalidServerNameError,
+        FileOperationError,
+        DirectoryError,
+        BackupWorldError,
+        AddonExtractError,
+    ) as e:
+        logger.error(
+            f"API: Failed to export world for '{server_name}': {e}", exc_info=True
+        )
         return {"status": "error", "message": f"Failed to export world: {e}"}
     except Exception as e:
-        logger.error(f"API: Unexpected error exporting world for '{server_name}': {e}", exc_info=True)
+        logger.error(
+            f"API: Unexpected error exporting world for '{server_name}': {e}",
+            exc_info=True,
+        )
         return {"status": "error", "message": f"Unexpected error exporting world: {e}"}
 
 
@@ -124,31 +161,54 @@ def import_world(
         raise MissingArgumentError(".mcworld file path cannot be empty.")
 
     selected_filename = os.path.basename(selected_file_path)
-    logger.info(f"API: Initiating world import for '{server_name}' from '{selected_filename}' (Stop/Start: {stop_start_server})")
+    logger.info(
+        f"API: Initiating world import for '{server_name}' from '{selected_filename}' (Stop/Start: {stop_start_server})"
+    )
 
     try:
         effective_base_dir = get_base_dir(base_dir)
         if not os.path.isfile(selected_file_path):
-            raise FileNotFoundError(f"Source .mcworld file not found: {selected_file_path}")
+            raise FileNotFoundError(
+                f"Source .mcworld file not found: {selected_file_path}"
+            )
 
-        imported_world_name: Optional[str] = None # To store the name for the message
+        imported_world_name: Optional[str] = None  # To store the name for the message
 
-        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
-            logger.info(f"API: Importing world from '{selected_filename}' into server '{server_name}'...")
+        with _server_stop_start_manager(
+            server_name, effective_base_dir, stop_start_server
+        ):
+            logger.info(
+                f"API: Importing world from '{selected_filename}' into server '{server_name}'..."
+            )
             # core_world.import_world handles getting level-name and extraction
             # It now returns the world_name string on success
-            imported_world_name = core_world.import_world(server_name, selected_file_path, effective_base_dir)
-        
-        logger.info(f"API: World import from '{selected_filename}' for server '{server_name}' completed.")
+            imported_world_name = core_world.import_world(
+                server_name, selected_file_path, effective_base_dir
+            )
+
+        logger.info(
+            f"API: World import from '{selected_filename}' for server '{server_name}' completed."
+        )
         return {
             "status": "success",
             "message": f"World '{imported_world_name or 'Unknown'}' imported successfully from {selected_filename}.",
         }
-    except ( MissingArgumentError, InvalidServerNameError, FileNotFoundError, FileOperationError, 
-             DirectoryError, DownloadExtractError, RestoreError # From core_world.import_world
-            ) as e:
-        logger.error(f"API: Failed to import world for '{server_name}': {e}", exc_info=True)
+    except (
+        MissingArgumentError,
+        InvalidServerNameError,
+        FileNotFoundError,
+        FileOperationError,
+        DirectoryError,
+        DownloadExtractError,
+        RestoreError,  # From core_world.import_world
+    ) as e:
+        logger.error(
+            f"API: Failed to import world for '{server_name}': {e}", exc_info=True
+        )
         return {"status": "error", "message": f"Failed to import world: {e}"}
     except Exception as e:
-        logger.error(f"API: Unexpected error importing world for '{server_name}': {e}", exc_info=True)
+        logger.error(
+            f"API: Unexpected error importing world for '{server_name}': {e}",
+            exc_info=True,
+        )
         return {"status": "error", "message": f"Unexpected error importing world: {e}"}

--- a/src/bedrock_server_manager/api/world.py
+++ b/src/bedrock_server_manager/api/world.py
@@ -1,12 +1,6 @@
 # bedrock-server-manager/bedrock_server_manager/api/world.py
 """
 Provides API-level functions for managing Bedrock server worlds.
-
-This module acts as an interface layer, orchestrating calls to core world
-and server functions for tasks like retrieving the current world name,
-exporting the world to a .mcworld archive, and importing a world from
-a .mcworld archive. Functions typically return a dictionary indicating
-success or failure status.
 """
 
 import os
@@ -15,21 +9,21 @@ from typing import Dict, Optional, Any
 
 # Local imports
 from bedrock_server_manager.config.settings import settings
-from bedrock_server_manager.core.system import base as system_base
+from bedrock_server_manager.api.utils import _server_stop_start_manager
 from bedrock_server_manager.error import (
     InvalidServerNameError,
     FileOperationError,
     DirectoryError,
     BackupWorldError,
-    RestoreError,
+    RestoreError,     
     DownloadExtractError,
     MissingArgumentError,
     FileNotFoundError,
+    AddonExtractError,
 )
-from bedrock_server_manager.api.server import start_server, stop_server
 from bedrock_server_manager.utils.general import get_base_dir, get_timestamp
 from bedrock_server_manager.core.server import (
-    server as server_base,
+    server as core_server_base,
     world as core_world,
 )
 
@@ -39,227 +33,79 @@ logger = logging.getLogger("bedrock_server_manager")
 def get_world_name(server_name: str, base_dir: Optional[str] = None) -> Dict[str, Any]:
     """
     Retrieves the configured world name (level-name) for a server.
-
-    Reads the value from the server's `server.properties` file via core functions.
-
-    Args:
-        server_name: The name of the server.
-        base_dir: Optional. The base directory for server installations. Uses config default if None.
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "world_name": str} on success.
-        - {"status": "error", "message": str} if the name cannot be retrieved or an error occurs.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If `base_dir` cannot be determined.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
-    logger.debug(f"Attempting to get world name for server '{server_name}'...")
+    logger.debug(f"API: Attempting to get world name for server '{server_name}'...")
     try:
         effective_base_dir = get_base_dir(base_dir)
-
-        # Call the core function which reads server.properties
-        # It raises FileOperationError if file/property missing or unreadable
-        world_name_str = server_base.get_world_name(server_name, effective_base_dir)
-
-        # The core function now raises if name isn't found, so direct return on success
-        logger.info(
-            f"Retrieved world name for server '{server_name}': '{world_name_str}'"
-        )
+        world_name_str = core_server_base.get_world_name(server_name, effective_base_dir)
+        logger.info(f"API: Retrieved world name for '{server_name}': '{world_name_str}'")
         return {"status": "success", "world_name": world_name_str}
-
-    except (
-        FileOperationError,
-        InvalidServerNameError,
-    ) as e:  # Catch specific errors from core or validation
-        logger.error(
-            f"Failed to get world name for server '{server_name}': {e}", exc_info=True
-        )
+    except (FileOperationError, InvalidServerNameError) as e:
+        logger.error(f"API: Failed to get world name for '{server_name}': {e}", exc_info=True)
         return {"status": "error", "message": f"Failed to get world name: {e}"}
     except Exception as e:
-        # Catch unexpected errors
-        logger.error(
-            f"Unexpected error getting world name for '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {
-            "status": "error",
-            "message": f"Unexpected error getting world name: {e}",
-        }
+        logger.error(f"API: Unexpected error getting world name for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error getting world name: {e}"}
 
 
 def export_world(
     server_name: str,
     base_dir: Optional[str] = None,
     export_dir: Optional[str] = None,
-    stop_start_server: Optional[bool] = True,
+    stop_start_server: bool = True,
 ) -> Dict[str, Any]:
     """
     Exports the server's currently configured world to a .mcworld archive file.
-
-    Determines the world path, creates the archive in the specified or default
-    export directory (BACKUP_DIR).
-
-    Args:
-        server_name: The name of the server whose world should be exported.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        export_dir: Optional. Directory to save the exported .mcworld file.
-                    Defaults to the configured BACKUP_DIR setting if None.
-        stop_start_server: If True, stop server before export and restart after if it was running.
-
-    Returns:
-        A dictionary indicating the outcome:
-        - {"status": "success", "export_file": str, "message": str} full path to the created file.
-        - {"status": "error", "message": str} on failure.
-
-    Raises:
-        MissingArgumentError: If `server_name` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileOperationError: If essential settings (BASE_DIR, BACKUP_DIR) are missing or
-                            `base_dir`/`export_dir` cannot be determined/created.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
-    logger.info(f"Initiating world export for server '{server_name}'...")
+    logger.info(f"API: Initiating world export for server '{server_name}' (Stop/Start: {stop_start_server})")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
-
-        # Determine and ensure export directory exists
         effective_export_dir: str
         if export_dir:
             effective_export_dir = export_dir
         else:
             backup_base_dir = settings.get("BACKUP_DIR")
             if not backup_base_dir:
-                raise FileOperationError("BACKUP_DIR setting missing.")
-            # Save into server-specific subfolder within backup dir
+                raise FileOperationError("BACKUP_DIR setting missing for default export directory.")
             effective_export_dir = os.path.join(backup_base_dir, server_name)
-
         os.makedirs(effective_export_dir, exist_ok=True)
-        logger.debug(f"Using export directory: {effective_export_dir}")
 
-        # Get the world name using the API function (which returns a dict)
-        world_name_result = get_world_name(server_name, effective_base_dir)
-        if world_name_result.get("status") == "error":
-            # Propagate the error message if world name couldn't be found
-            logger.error(
-                f"Cannot export world for '{server_name}': {world_name_result.get('message')}"
-            )
-            return world_name_result
+        # Get world name directly from core
+        world_name_str = core_server_base.get_world_name(server_name, effective_base_dir)
+        world_path = os.path.join(effective_base_dir, server_name, "worlds", world_name_str)
 
-        world_name = world_name_result["world_name"]
-        world_path = os.path.join(effective_base_dir, server_name, "worlds", world_name)
-
-        # Check world directory exists before attempting export
         if not os.path.isdir(world_path):
-            raise DirectoryError(
-                f"World directory '{world_name}' not found at expected location: {world_path}"
-            )
+            raise DirectoryError(f"World directory '{world_name_str}' not found at: {world_path}")
 
-        # Construct export filename
         timestamp = get_timestamp()
-        export_filename = f"{world_name}_export_{timestamp}.mcworld"
+        export_filename = f"{world_name_str}_export_{timestamp}.mcworld"
         export_file_path = os.path.join(effective_export_dir, export_filename)
 
-        was_running = False
-        # --- Server Stop ---
-        if stop_start_server:
-            try:
-                logger.debug(
-                    f"Checking running status for '{server_name}' before world export..."
-                )
-                if system_base.is_server_running(server_name, effective_base_dir):
-                    was_running = True
-                    logger.info(
-                        f"Server '{server_name}' is running. Stopping for world export..."
-                    )
-                    stop_result = stop_server(
-                        server_name, effective_base_dir
-                    )  # API func returns dict
-                    if stop_result.get("status") == "error":
-                        logger.error(
-                            f"Failed to stop server '{server_name}' for export: {stop_result.get('message')}"
-                        )
-                        return stop_result
-                    logger.info(f"Server '{server_name}' stopped.")
-                else:
-                    logger.debug(f"Server '{server_name}' is not running.")
-            except Exception as e:
-                logger.error(
-                    f"Error stopping server '{server_name}' for world export: {e}",
-                    exc_info=True,
-                )
-                return {
-                    "status": "error",
-                    "message": f"Failed to stop server for export: {e}",
-                }
-
-        logger.info(
-            f"Exporting world '{world_name}' from '{world_path}' to '{export_file_path}'..."
-        )
-
-        # Call the core export function
-        core_world.export_world(
-            world_path, export_file_path
-        )  # Raises BackupWorldError, DirectoryError, FileOperationError
-
-        # --- Server Restart ---
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            logger.info(f"Restarting server '{server_name}' after world export...")
-            try:
-                start_result = start_server(
-                    server_name, effective_base_dir
-                )  # API func returns dict
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after import: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after import: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-        logger.info(
-            f"World for server '{server_name}' exported successfully to '{export_file_path}'."
-        )
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            logger.info(f"API: Exporting world '{world_name_str}' from '{world_path}' to '{export_file_path}'...")
+            core_world.export_world(world_path, export_file_path)
+        
+        logger.info(f"API: World for server '{server_name}' exported to '{export_file_path}'.")
         return {
             "status": "success",
             "export_file": export_file_path,
-            "message": "World exported successfully.",
+            "message": f"World '{world_name_str}' exported successfully to {export_filename}.",
         }
-
-    except (
-        DirectoryError,
-        BackupWorldError,
-        FileOperationError,
-        InvalidServerNameError,
-    ) as e:
-        # Catch specific errors from core functions or setup
-        logger.error(
-            f"Failed to export world for server '{server_name}': {e}", exc_info=True
-        )
+    except ( MissingArgumentError, InvalidServerNameError, FileOperationError, DirectoryError,
+             BackupWorldError,
+             AddonExtractError
+            ) as e:
+        logger.error(f"API: Failed to export world for '{server_name}': {e}", exc_info=True)
         return {"status": "error", "message": f"Failed to export world: {e}"}
     except Exception as e:
-        # Catch unexpected errors
-        logger.error(
-            f"Unexpected error exporting world for '{server_name}': {e}", exc_info=True
-        )
+        logger.error(f"API: Unexpected error exporting world for '{server_name}': {e}", exc_info=True)
         return {"status": "error", "message": f"Unexpected error exporting world: {e}"}
 
 
@@ -271,25 +117,6 @@ def import_world(
 ) -> Dict[str, str]:
     """
     Imports a world from a .mcworld file, replacing the server's current world.
-
-    Determines the target world directory based on `server.properties`, optionally
-    stops/starts the server, and calls the core extraction function.
-
-    Args:
-        server_name: The name of the server to import the world into.
-        selected_file_path: The full path to the .mcworld file to import.
-        base_dir: Optional. Base directory for server installations. Uses config default if None.
-        stop_start_server: If True, stop server before import and restart after if it was running.
-
-    Returns:
-        A dictionary indicating the outcome: `{"status": "success", "message": ...}` or
-        `{"status": "error", "message": ...}`.
-
-    Raises:
-        MissingArgumentError: If `server_name` or `selected_file_path` is empty.
-        InvalidServerNameError: If `server_name` is invalid.
-        FileNotFoundError: If `selected_file_path` does not exist.
-        FileOperationError: If `base_dir` cannot be determined.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
@@ -297,144 +124,31 @@ def import_world(
         raise MissingArgumentError(".mcworld file path cannot be empty.")
 
     selected_filename = os.path.basename(selected_file_path)
-    logger.info(
-        f"Initiating world import for server '{server_name}' from file '{selected_filename}'. Stop/Start: {stop_start_server}"
-    )
+    logger.info(f"API: Initiating world import for '{server_name}' from '{selected_filename}' (Stop/Start: {stop_start_server})")
 
     try:
         effective_base_dir = get_base_dir(base_dir)
-        # Check source file exists before potentially stopping server
         if not os.path.isfile(selected_file_path):
-            raise FileNotFoundError(
-                f"Source .mcworld file not found: {selected_file_path}"
-            )
+            raise FileNotFoundError(f"Source .mcworld file not found: {selected_file_path}")
 
-    except (FileOperationError, FileNotFoundError) as e:
-        logger.error(
-            f"Pre-import check failed for world import on server '{server_name}': {e}",
-            exc_info=True,
-        )
-        return {
-            "status": "error",
-            "message": f"Configuration error or source file not found: {e}",
-        }
+        imported_world_name: Optional[str] = None # To store the name for the message
 
-    was_running = False
-    # --- Server Stop ---
-    if stop_start_server:
-        try:
-            logger.debug(
-                f"Checking running status for '{server_name}' before world import..."
-            )
-            if system_base.is_server_running(server_name, effective_base_dir):
-                was_running = True
-                logger.info(
-                    f"Server '{server_name}' is running. Stopping for world import..."
-                )
-                stop_result = stop_server(
-                    server_name, effective_base_dir
-                )  # API func returns dict
-                if stop_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to stop server '{server_name}' for import: {stop_result.get('message')}"
-                    )
-                    return stop_result
-                logger.info(f"Server '{server_name}' stopped.")
-            else:
-                logger.debug(f"Server '{server_name}' is not running.")
-        except Exception as e:
-            logger.error(
-                f"Error stopping server '{server_name}' for world import: {e}",
-                exc_info=True,
-            )
-            return {
-                "status": "error",
-                "message": f"Failed to stop server for import: {e}",
-            }
-
-    # --- Core Import/Extraction Operation ---
-    import_error = None
-    try:
-        # Get world name (API function returns dict)
-        world_name_result = get_world_name(server_name, effective_base_dir)
-        if world_name_result.get("status") == "error":
-            raise FileOperationError(
-                world_name_result.get("message", "Could not determine world name.")
-            )
-
-        world_name = world_name_result["world_name"]
-        # Construct full path to target world directory
-        target_world_dir = os.path.join(
-            effective_base_dir, server_name, "worlds", world_name
-        )
-        logger.info(f"Target directory for world import: {target_world_dir}")
-
-        # Call core function to extract (handles cleaning target dir)
-        # Raises FileNotFoundError, DownloadExtractError, FileOperationError
-        core_world.extract_world(selected_file_path, target_world_dir)
-        logger.info(
-            f"Core world extraction function completed for server '{server_name}'."
-        )
-
-    except (
-        FileNotFoundError,
-        DownloadExtractError,
-        FileOperationError,
-        DirectoryError,
-        InvalidServerNameError,
-    ) as e:
-        import_error = e
-        logger.error(
-            f"World import failed for server '{server_name}' from '{selected_filename}': {e}",
-            exc_info=True,
-        )
-    except Exception as e:
-        import_error = e
-        logger.error(
-            f"Unexpected error during world import for server '{server_name}': {e}",
-            exc_info=True,
-        )
-
-    # --- Server Restart ---
-    finally:
-        restart_error_dict = None
-        if stop_start_server and was_running:
-            if import_error:
-                logger.warning(
-                    f"Attempting to restart server '{server_name}' even though world import failed."
-                )
-            else:
-                logger.info(f"Restarting server '{server_name}' after world import...")
-            try:
-                start_result = start_server(
-                    server_name, effective_base_dir
-                )  # API func returns dict
-                if start_result.get("status") == "error":
-                    logger.error(
-                        f"Failed to restart server '{server_name}' after import: {start_result.get('message')}"
-                    )
-                    restart_error_dict = start_result
-                else:
-                    logger.info(f"Server '{server_name}' restart initiated.")
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error restarting server '{server_name}' after import: {e}",
-                    exc_info=True,
-                )
-                restart_error_dict = {
-                    "status": "error",
-                    "message": f"Unexpected error restarting server: {e}",
-                }
-
-    # --- Final Result ---
-    if import_error:
-        # Use RestoreError conceptually for import failures at API level
-        wrapped_error = RestoreError(f"World import failed: {import_error}")
-        return {"status": "error", "message": str(wrapped_error)}
-    elif restart_error_dict:
-        return restart_error_dict
-    else:
+        with _server_stop_start_manager(server_name, effective_base_dir, stop_start_server):
+            logger.info(f"API: Importing world from '{selected_filename}' into server '{server_name}'...")
+            # core_world.import_world handles getting level-name and extraction
+            # It now returns the world_name string on success
+            imported_world_name = core_world.import_world(server_name, selected_file_path, effective_base_dir)
+        
+        logger.info(f"API: World import from '{selected_filename}' for server '{server_name}' completed.")
         return {
             "status": "success",
-            "message": f"World import from '{selected_filename}' completed successfully.",
+            "message": f"World '{imported_world_name or 'Unknown'}' imported successfully from {selected_filename}.",
         }
+    except ( MissingArgumentError, InvalidServerNameError, FileNotFoundError, FileOperationError, 
+             DirectoryError, DownloadExtractError, RestoreError # From core_world.import_world
+            ) as e:
+        logger.error(f"API: Failed to import world for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Failed to import world: {e}"}
+    except Exception as e:
+        logger.error(f"API: Unexpected error importing world for '{server_name}': {e}", exc_info=True)
+        return {"status": "error", "message": f"Unexpected error importing world: {e}"}

--- a/src/bedrock_server_manager/cli/main_menus.py
+++ b/src/bedrock_server_manager/cli/main_menus.py
@@ -231,7 +231,7 @@ def manage_server(base_dir: str, config_dir: str) -> None:
             elif choice == "2":
                 logger.debug(f"User selected 'Start Server' for '{server_name}'.")
                 # Call start handler
-                cli_server.start_server(server_name, base_dir)
+                cli_server.start_server(server_name, base_dir, "detached")
             elif choice == "3":
                 logger.debug(f"User selected 'Stop Server' for '{server_name}'.")
                 # Call stop handler

--- a/src/bedrock_server_manager/cli/main_menus.py
+++ b/src/bedrock_server_manager/cli/main_menus.py
@@ -92,10 +92,7 @@ def main_menu(base_dir: str, config_dir: Optional[str] = None) -> None:
             print("  1) Install New Server")
             print("  2) Manage Existing Server")
             print("  3) Install Content")
-            print(
-                "  4) Send Command to Server"
-                + (" (Linux Only)" if platform.system() != "Linux" else "")
-            )
+            print("  4) Send Command to Server")
             print("  5) Advanced")
             print("  6) Exit")
             prompt_range = "[1-6]"

--- a/src/bedrock_server_manager/cli/server.py
+++ b/src/bedrock_server_manager/cli/server.py
@@ -59,7 +59,9 @@ from bedrock_server_manager.utils.general import (
 logger = logging.getLogger("bedrock_server_manager")
 
 
-def start_server(server_name: str, base_dir: Optional[str] = None) -> None:
+def start_server(
+    server_name: str, base_dir: Optional[str] = None, mode: str = "direct"
+) -> None:
     """
     CLI handler function to start a specific Bedrock server instance.
 
@@ -81,7 +83,7 @@ def start_server(server_name: str, base_dir: Optional[str] = None) -> None:
     try:
         # Call the API function
         logger.debug(f"Calling API: server_api.start_server for '{server_name}'")
-        response: Dict[str, Any] = server_api.start_server(server_name, base_dir)
+        response: Dict[str, Any] = server_api.start_server(server_name, base_dir, mode)
         logger.debug(f"API response from start_server: {response}")
 
         # --- User Interaction: Print Result ---

--- a/src/bedrock_server_manager/cli/server_install_config.py
+++ b/src/bedrock_server_manager/cli/server_install_config.py
@@ -1039,7 +1039,7 @@ def install_new_server(
             logger.debug(f"User choice for starting server: '{start_choice}'")
             if start_choice in ("yes", "y", ""):  # Default empty to yes
                 # Call CLI start function
-                cli_server.start_server(server_name, effective_base_dir)
+                cli_server.start_server(server_name, effective_base_dir, "detached")
                 break
             elif start_choice in ("no", "n"):
                 print(

--- a/src/bedrock_server_manager/core/server/backup.py
+++ b/src/bedrock_server_manager/core/server/backup.py
@@ -195,9 +195,7 @@ def backup_world_data(world_path: str, backup_dir: str, world_name: str) -> str:
     logger.info(f"Creating world backup file: '{backup_filename}' in '{backup_dir}'...")
 
     try:
-        core_world.export_world(
-            world_path, backup_file_path
-        )
+        core_world.export_world(world_path, backup_file_path)
         logger.info(f"World backup created successfully: {backup_file_path}")
         return backup_file_path
     except (AddonExtractError, FileOperationError) as e:
@@ -299,21 +297,31 @@ def backup_all_server_data(server_name: str, base_dir: str) -> Dict[str, Optiona
                           Other config backup failures are reported in the return dict.
     """
     if not server_name:
-        raise MissingArgumentError("Server name cannot be empty for backup_all_server_data.")
+        raise MissingArgumentError(
+            "Server name cannot be empty for backup_all_server_data."
+        )
     if not base_dir:
-        raise MissingArgumentError("Base directory cannot be empty for backup_all_server_data.")
+        raise MissingArgumentError(
+            "Base directory cannot be empty for backup_all_server_data."
+        )
 
     backup_base_dir = settings.get("BACKUP_DIR")
     if not backup_base_dir:
-        raise FileOperationError("BACKUP_DIR setting is missing or empty in configuration.")
+        raise FileOperationError(
+            "BACKUP_DIR setting is missing or empty in configuration."
+        )
     server_backup_dir = os.path.join(backup_base_dir, server_name)
 
     try:
         os.makedirs(server_backup_dir, exist_ok=True)
     except OSError as e:
-        raise FileOperationError(f"Cannot create server backup directory '{server_backup_dir}': {e}") from e
+        raise FileOperationError(
+            f"Cannot create server backup directory '{server_backup_dir}': {e}"
+        ) from e
 
-    logger.info(f"Starting full backup process for server: '{server_name}' into '{server_backup_dir}'")
+    logger.info(
+        f"Starting full backup process for server: '{server_name}' into '{server_backup_dir}'"
+    )
     backup_results: Dict[str, Optional[str]] = {}
 
     # 1. Backup World
@@ -321,10 +329,14 @@ def backup_all_server_data(server_name: str, base_dir: str) -> Dict[str, Optiona
         logger.info("Backing up server world...")
         world_name = core_server_utils.get_world_name(server_name, base_dir)
         world_path = os.path.join(base_dir, server_name, "worlds", world_name)
-        backup_results["world"] = backup_world_data(world_path, server_backup_dir, world_name)
+        backup_results["world"] = backup_world_data(
+            world_path, server_backup_dir, world_name
+        )
         logger.info("World backup completed.")
-    except Exception as e: # Catching broader exceptions here for the component
-        logger.error(f"World backup failed for server '{server_name}': {e}", exc_info=True)
+    except Exception as e:  # Catching broader exceptions here for the component
+        logger.error(
+            f"World backup failed for server '{server_name}': {e}", exc_info=True
+        )
         backup_results["world"] = None
         # Depending on desired atomicity, you might choose to raise BackupWorldError here
         # and halt, or continue with configs. Current approach: continue.
@@ -350,12 +362,19 @@ def backup_all_server_data(server_name: str, base_dir: str) -> Dict[str, Optiona
             logger.warning(
                 f"Config file '{config_file_name}' not found for server '{server_name}'. Skipping backup for this file."
             )
-            backup_results[config_file_name] = None # Explicitly mark as not backed up / skipped
+            backup_results[config_file_name] = (
+                None  # Explicitly mark as not backed up / skipped
+            )
 
-    if all(value is None for value in backup_results.values() if value is not None): # if all attempted backups failed
-        if backup_results.get("world") is None and "world" in backup_results: # Check if world backup was attempted and failed
-             raise BackupWorldError(f"Core world backup failed for '{server_name}' and no other components succeeded.")
-
+    if all(
+        value is None for value in backup_results.values() if value is not None
+    ):  # if all attempted backups failed
+        if (
+            backup_results.get("world") is None and "world" in backup_results
+        ):  # Check if world backup was attempted and failed
+            raise BackupWorldError(
+                f"Core world backup failed for '{server_name}' and no other components succeeded."
+            )
 
     return backup_results
 
@@ -389,8 +408,8 @@ def restore_config_file_data(backup_file_path: str, server_dir: str) -> str:
 
     if not os.path.exists(backup_file_path):
         raise FileNotFoundError(f"Backup file not found: '{backup_file_path}'")
-    if not os.path.isdir(server_dir): # server_dir must exist for restore
-        os.makedirs(server_dir, exist_ok=True) # Create if not exists
+    if not os.path.isdir(server_dir):  # server_dir must exist for restore
+        os.makedirs(server_dir, exist_ok=True)  # Create if not exists
         # raise FileOperationError(
         #     f"Target server directory does not exist or is not a directory: '{server_dir}'"
         # )
@@ -423,7 +442,9 @@ def restore_config_file_data(backup_file_path: str, server_dir: str) -> str:
         ) from e
 
 
-def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Optional[str]]:
+def restore_all_server_data(
+    server_name: str, base_dir: str
+) -> Dict[str, Optional[str]]:
     """
     Restores a server to its latest backed-up state (world and config files).
     Returns a dictionary of restored components and their original paths, or None if failed.
@@ -443,10 +464,13 @@ def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Option
         RestoreError: If any critical restore operation fails.
     """
     if not server_name:
-        raise MissingArgumentError("Server name cannot be empty for restore_all_server_data.")
+        raise MissingArgumentError(
+            "Server name cannot be empty for restore_all_server_data."
+        )
     if not base_dir:
-        raise MissingArgumentError("Base directory cannot be empty for restore_all_server_data.")
-
+        raise MissingArgumentError(
+            "Base directory cannot be empty for restore_all_server_data."
+        )
 
     backup_base_dir = settings.get("BACKUP_DIR")
     if not backup_base_dir:
@@ -463,9 +487,9 @@ def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Option
         logger.warning(
             f"No backup directory found for server '{server_name}' at '{server_backup_dir}'. Cannot restore."
         )
-        return {} # Return empty if no backup dir
+        return {}  # Return empty if no backup dir
 
-    os.makedirs(server_install_dir, exist_ok=True) # Ensure server install dir exists
+    os.makedirs(server_install_dir, exist_ok=True)  # Ensure server install dir exists
 
     restore_results: Dict[str, Optional[str]] = {}
     failures = []
@@ -483,7 +507,9 @@ def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Option
             imported_world_name = core_world.import_world(
                 server_name, latest_world_backup, base_dir
             )
-            restore_results["world"] = os.path.join(server_install_dir, "worlds", imported_world_name)
+            restore_results["world"] = os.path.join(
+                server_install_dir, "worlds", imported_world_name
+            )
         else:
             logger.info("No .mcworld backup files found. Skipping world restore.")
             restore_results["world"] = None
@@ -494,9 +520,8 @@ def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Option
         failures.append(f"World ({type(e).__name__})")
         restore_results["world"] = None
 
-
     # 2. Restore Config Files (Latest of each type)
-    config_file_map = { # maps original name to backup prefix
+    config_file_map = {  # maps original name to backup prefix
         "server.properties": "server_backup_",
         "allowlist.json": "allowlist_backup_",
         "permissions.json": "permissions_backup_",
@@ -514,8 +539,12 @@ def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Option
             # e.g. world_backup_....json should not match permissions_backup_....json
             # This regex is basic, might need refinement for complex prefixes
             valid_config_backups = [
-                b_path for b_path in config_backups
-                if re.match(f"^{re.escape(name_part)}_backup_\\d{{8}}_\\d{{6}}{re.escape(ext_part)}$", os.path.basename(b_path))
+                b_path
+                for b_path in config_backups
+                if re.match(
+                    f"^{re.escape(name_part)}_backup_\\d{{8}}_\\d{{6}}{re.escape(ext_part)}$",
+                    os.path.basename(b_path),
+                )
             ]
 
             if valid_config_backups:
@@ -539,7 +568,6 @@ def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Option
             )
             failures.append(f"{original_filename} ({type(e).__name__})")
             restore_results[original_filename] = None
-
 
     if failures:
         error_summary = ", ".join(failures)

--- a/src/bedrock_server_manager/core/server/backup.py
+++ b/src/bedrock_server_manager/core/server/backup.py
@@ -9,12 +9,12 @@ import glob
 import re
 import shutil
 import logging
-from typing import Optional
+from typing import Optional, Dict
 
 # Local imports
 from bedrock_server_manager.config.settings import settings
-from bedrock_server_manager.core.server import world
-from bedrock_server_manager.core.server import server
+from bedrock_server_manager.core.server import world as core_world
+from bedrock_server_manager.core.server import server as core_server_utils
 from bedrock_server_manager.error import (
     MissingArgumentError,
     FileOperationError,
@@ -58,7 +58,6 @@ def prune_old_backups(
     )
 
     if not os.path.isdir(backup_dir):
-        # It's okay if the directory doesn't exist yet, just means no backups to prune.
         if os.path.exists(backup_dir):
             error_msg = f"Backup path '{backup_dir}' exists but is not a directory."
             logger.error(error_msg)
@@ -79,16 +78,13 @@ def prune_old_backups(
         )
         raise ValueError(f"Invalid value for backups to keep: {e}") from e
 
-    # Construct the search pattern for glob
     if not file_prefix and not file_extension:
         error_msg = "Cannot prune backups without specifying either a file_prefix or file_extension."
         logger.error(error_msg)
         raise InvalidInputError(error_msg)
 
-    # Build pattern
     pattern = file_prefix + "*"
     if file_extension:
-        # Ensure extension doesn't start with a dot if provided that way
         cleaned_extension = file_extension.lstrip(".")
         pattern += "." + cleaned_extension
 
@@ -96,8 +92,6 @@ def prune_old_backups(
     logger.debug(f"Using glob pattern for pruning: '{glob_pattern}'")
 
     try:
-        # Find matching backup files
-        # Sort by modification time, newest first (reverse=True)
         backup_files = sorted(
             glob.glob(glob_pattern), key=os.path.getmtime, reverse=True
         )
@@ -107,7 +101,7 @@ def prune_old_backups(
 
         if len(backup_files) > num_to_keep:
             num_to_delete = len(backup_files) - num_to_keep
-            files_to_delete = backup_files[num_to_keep:]  # Get the oldest files
+            files_to_delete = backup_files[num_to_keep:]
             logger.info(
                 f"Found {len(backup_files)} backups. Deleting {num_to_delete} oldest file(s) to keep {num_to_keep}."
             )
@@ -125,19 +119,15 @@ def prune_old_backups(
                         f"Failed to remove old backup '{old_backup_path}': {e}",
                         exc_info=True,
                     )
-                    # Continue trying to delete others, but report the overall failure later
             if deleted_count < num_to_delete:
-                # If some deletions failed, raise error after trying all
                 raise FileOperationError(
                     f"Failed to delete all required old backups ({num_to_delete - deleted_count} deletion(s) failed). Check logs."
                 )
             logger.info(f"Successfully deleted {deleted_count} old backup(s).")
-
         else:
             logger.info(
                 f"Found {len(backup_files)} backup(s), which is not more than the {num_to_keep} to keep. No files deleted."
             )
-
     except OSError as e:
         logger.error(
             f"OS error occurred while accessing or pruning backups in '{backup_dir}': {e}",
@@ -145,28 +135,31 @@ def prune_old_backups(
         )
         raise FileOperationError(f"Error pruning backups in '{backup_dir}': {e}") from e
     except Exception as e:
-        # Catch unexpected errors during glob or sorting
         logger.error(
             f"Unexpected error during backup pruning process: {e}", exc_info=True
         )
         raise FileOperationError(f"Unexpected error during backup pruning: {e}") from e
 
 
-def backup_world(world_path: str, backup_dir: str, world_name: str) -> None:
+def backup_world_data(world_path: str, backup_dir: str, world_name: str) -> str:
     """
     Creates a backup of a specific world directory as an .mcworld file.
+    This function now returns the path to the created backup file.
 
     Args:
         world_path: The full path to the source world directory.
         backup_dir: The directory where the .mcworld backup file will be saved.
         world_name: The name of the world (used for the backup filename).
 
+    Returns:
+        The full path to the created .mcworld backup file.
+
     Raises:
         MissingArgumentError: If required arguments are empty.
         DirectoryError: If `world_path` does not exist or is not a directory.
         FileOperationError: If creating the backup directory fails, or if
-                            the world export process fails (raised by world.export_world).
-        AddonExtractError: If zipping the world fails (raised by world.export_world).
+                            the world export process fails (raised by core_world.export_world).
+        AddonExtractError: If zipping the world fails (raised by core_world.export_world).
     """
     if not world_path:
         raise MissingArgumentError("World path cannot be empty.")
@@ -184,7 +177,6 @@ def backup_world(world_path: str, backup_dir: str, world_name: str) -> None:
         logger.error(error_msg)
         raise DirectoryError(error_msg)
 
-    # Ensure backup directory exists
     try:
         os.makedirs(backup_dir, exist_ok=True)
         logger.debug(f"Ensured backup directory exists: {backup_dir}")
@@ -197,24 +189,23 @@ def backup_world(world_path: str, backup_dir: str, world_name: str) -> None:
         ) from e
 
     timestamp = general.get_timestamp()
-    # Use the provided world_name for the filename base
     backup_filename = f"{world_name}_backup_{timestamp}.mcworld"
     backup_file_path = os.path.join(backup_dir, backup_filename)
 
     logger.info(f"Creating world backup file: '{backup_filename}' in '{backup_dir}'...")
 
     try:
-        # Delegate the actual zipping process to the world module
-        world.export_world(
+        core_world.export_world(
             world_path, backup_file_path
-        )  # Raises AddonExtractError, FileOperationError
+        )
         logger.info(f"World backup created successfully: {backup_file_path}")
+        return backup_file_path
     except (AddonExtractError, FileOperationError) as e:
         logger.error(
             f"Failed to export world '{world_path}' to '{backup_file_path}': {e}",
             exc_info=True,
         )
-        raise  # Re-raise the specific error from world.export_world
+        raise
     except Exception as e:
         logger.error(f"Unexpected error during world export: {e}", exc_info=True)
         raise FileOperationError(
@@ -222,13 +213,17 @@ def backup_world(world_path: str, backup_dir: str, world_name: str) -> None:
         ) from e
 
 
-def backup_config_file(file_to_backup: str, backup_dir: str) -> None:
+def backup_single_config_file(file_to_backup: str, backup_dir: str) -> str:
     """
     Creates a timestamped backup copy of a single configuration file.
+    This function now returns the path to the created backup file.
 
     Args:
         file_to_backup: The full path to the configuration file to back up.
         backup_dir: The directory where the backup copy will be saved.
+
+    Returns:
+        The full path to the created backup config file.
 
     Raises:
         MissingArgumentError: If `file_to_backup` or `backup_dir` is empty.
@@ -248,7 +243,6 @@ def backup_config_file(file_to_backup: str, backup_dir: str) -> None:
         logger.error(error_msg)
         raise FileNotFoundError(error_msg)
 
-    # Ensure backup directory exists
     try:
         os.makedirs(backup_dir, exist_ok=True)
         logger.debug(f"Ensured backup directory exists: {backup_dir}")
@@ -260,7 +254,6 @@ def backup_config_file(file_to_backup: str, backup_dir: str) -> None:
             f"Cannot create backup directory '{backup_dir}': {e}"
         ) from e
 
-    # Construct backup filename (e.g., server.properties -> server_backup_YYYYMMDD_HHMMSS.properties)
     name_part, ext_part = os.path.splitext(file_basename)
     timestamp = general.get_timestamp()
     backup_filename = f"{name_part}_backup_{timestamp}{ext_part}"
@@ -270,11 +263,11 @@ def backup_config_file(file_to_backup: str, backup_dir: str) -> None:
         f"Copying '{file_basename}' to backup destination: '{destination_path}'"
     )
     try:
-        # copy2 preserves metadata like modification time
         shutil.copy2(file_to_backup, destination_path)
         logger.info(
             f"Config file '{file_basename}' backed up successfully to '{backup_filename}' in '{backup_dir}'."
         )
+        return destination_path
     except OSError as e:
         logger.error(
             f"Failed to copy config file '{file_to_backup}' to '{destination_path}': {e}",
@@ -285,252 +278,99 @@ def backup_config_file(file_to_backup: str, backup_dir: str) -> None:
         ) from e
 
 
-def backup_server(
-    server_name: str,
-    backup_type: str,
-    base_dir: str,
-    file_to_backup: Optional[str] = None,
-) -> None:
+def backup_all_server_data(server_name: str, base_dir: str) -> Dict[str, Optional[str]]:
     """
-    Manages the backup process for either a server's world or a specific config file.
-
-    Coordinates determining paths, creating backup directories, and calling the
-    appropriate backup function (`backup_world` or `backup_config_file`). Also handles pruning.
-
-    Args:
-        server_name: The name of the server.
-        backup_type: The type of backup to perform ("world" or "config").
-        base_dir: The base directory containing all server installations.
-        file_to_backup: The relative path (from server base) of the config file
-                        to back up if `backup_type` is "config". Required in that case.
-
-    Raises:
-        MissingArgumentError: If required arguments are missing for the specified `backup_type`.
-        InvalidInputError: If `backup_type` is not "world" or "config".
-        BackupWorldError: If a world backup fails (wraps underlying errors).
-        FileOperationError: If getting world name fails, config backup fails, or pruning fails.
-        DirectoryError: If world directory is not found.
-        ValueError: If backup_keep setting is invalid during pruning.
-    """
-    if not server_name:
-        raise MissingArgumentError("Server name cannot be empty.")
-    if not backup_type:
-        raise MissingArgumentError("Backup type cannot be empty.")
-    if not base_dir:
-        raise MissingArgumentError("Base directory cannot be empty.")
-
-    # Normalize backup type
-    backup_type = backup_type.lower()
-    logger.info(f"Initiating '{backup_type}' backup for server '{server_name}'.")
-
-    # Determine backup directory path
-    backup_base_dir = settings.get("BACKUP_DIR")
-    if not backup_base_dir:
-        raise FileOperationError(
-            "BACKUP_DIR setting is missing or empty in configuration."
-        )
-    server_backup_dir = os.path.join(backup_base_dir, server_name)
-
-    # Ensure the server-specific backup directory exists (needed for both types)
-    try:
-        os.makedirs(server_backup_dir, exist_ok=True)
-        logger.debug(f"Ensured server backup directory exists: {server_backup_dir}")
-    except OSError as e:
-        logger.error(
-            f"Failed to create server backup directory '{server_backup_dir}': {e}",
-            exc_info=True,
-        )
-        raise FileOperationError(
-            f"Cannot create server backup directory '{server_backup_dir}': {e}"
-        ) from e
-
-    if backup_type == "world":
-        try:
-            # Determine world path
-            world_name = server.get_world_name(
-                server_name, base_dir
-            )  # Raises FileOperationError
-            if not world_name:
-                raise FileOperationError(
-                    f"Could not determine world name for server '{server_name}'. Cannot perform world backup."
-                )
-            world_path = os.path.join(base_dir, server_name, "worlds", world_name)
-
-            # Perform world backup
-            backup_world(
-                world_path, server_backup_dir, world_name
-            )  # Raises DirectoryError, FileOperationError, AddonExtractError
-
-        except (
-            DirectoryError,
-            AddonExtractError,
-            FileOperationError,
-        ) as e:
-            logger.error(
-                f"World backup process failed for server '{server_name}': {e}",
-                exc_info=True,
-            )
-            raise BackupWorldError(
-                f"World backup failed for '{server_name}': {e}"
-            ) from e
-        except Exception as e:
-            logger.error(
-                f"Unexpected error during world backup for server '{server_name}': {e}",
-                exc_info=True,
-            )
-            raise BackupWorldError(
-                f"Unexpected world backup error for '{server_name}': {e}"
-            ) from e
-
-    elif backup_type == "config":
-        if not file_to_backup:
-            raise MissingArgumentError(
-                "Config file path is required for backup type 'config'."
-            )
-
-        full_config_path = os.path.join(base_dir, server_name, file_to_backup)
-        config_filename = os.path.basename(file_to_backup)
-        name_part, ext_part = os.path.splitext(config_filename)
-
-        try:
-            # Perform config file backup
-            backup_config_file(
-                full_config_path, server_backup_dir
-            )  # Raises FileNotFoundError, FileOperationError
-
-        except (
-            FileNotFoundError,
-            FileOperationError,
-        ) as e:
-            logger.error(
-                f"Config backup process failed for '{config_filename}' on server '{server_name}': {e}",
-                exc_info=True,
-            )
-            raise FileOperationError(
-                f"Config backup failed for '{config_filename}': {e}"
-            ) from e
-        except Exception as e:
-            logger.error(
-                f"Unexpected error during config backup for '{config_filename}' on server '{server_name}': {e}",
-                exc_info=True,
-            )
-            raise FileOperationError(
-                f"Unexpected config backup error for '{config_filename}': {e}"
-            ) from e
-
-    else:
-        logger.error(
-            f"Invalid backup type provided: '{backup_type}'. Must be 'world' or 'config'."
-        )
-        raise InvalidInputError(f"Invalid backup type: {backup_type}")
-
-
-def backup_all(server_name: str, base_dir: Optional[str] = None) -> None:
-    """
-    Performs a full backup of a server, including its world and standard config files.
+    Performs a full backup of a server: its world and standard config files.
+    Returns a dictionary of backed up components and their paths, or None if failed.
 
     Args:
         server_name: The name of the server to back up.
-        base_dir: Optional. The base directory containing all server installations.
-                  Defaults to the value from application settings if None.
+        base_dir: The base directory containing all server installations.
+
+    Returns:
+        A dictionary mapping component type (e.g., "world", "server.properties")
+        to the path of its backup file, or None if that component's backup failed.
 
     Raises:
-        MissingArgumentError: If `server_name` is empty.
-        BackupWorldError: If the world backup fails.
-        FileOperationError: If any configuration file backup fails, or if determining
-                            world name fails. Also raised if BACKUP_DIR setting is missing.
-        # Other exceptions related to pruning might be raised indirectly.
+        MissingArgumentError: If `server_name` or `base_dir` is empty.
+        FileOperationError: If essential settings (BACKUP_DIR) are missing, or if
+                            determining world name fails.
+        BackupWorldError: If the world backup specifically fails catastrophically.
+                          Other config backup failures are reported in the return dict.
     """
     if not server_name:
-        raise MissingArgumentError("Server name cannot be empty for backup_all.")
+        raise MissingArgumentError("Server name cannot be empty for backup_all_server_data.")
+    if not base_dir:
+        raise MissingArgumentError("Base directory cannot be empty for backup_all_server_data.")
 
-    # Use provided base_dir or get from settings
-    effective_base_dir = base_dir if base_dir is not None else settings.get("BASE_DIR")
-    if not effective_base_dir:
-        raise FileOperationError(
-            "BASE_DIR setting is missing or empty in configuration."
-        )
+    backup_base_dir = settings.get("BACKUP_DIR")
+    if not backup_base_dir:
+        raise FileOperationError("BACKUP_DIR setting is missing or empty in configuration.")
+    server_backup_dir = os.path.join(backup_base_dir, server_name)
 
-    logger.info(f"Starting full backup process for server: '{server_name}'")
+    try:
+        os.makedirs(server_backup_dir, exist_ok=True)
+    except OSError as e:
+        raise FileOperationError(f"Cannot create server backup directory '{server_backup_dir}': {e}") from e
+
+    logger.info(f"Starting full backup process for server: '{server_name}' into '{server_backup_dir}'")
+    backup_results: Dict[str, Optional[str]] = {}
 
     # 1. Backup World
     try:
         logger.info("Backing up server world...")
-        backup_server(server_name, "world", effective_base_dir)
+        world_name = core_server_utils.get_world_name(server_name, base_dir)
+        world_path = os.path.join(base_dir, server_name, "worlds", world_name)
+        backup_results["world"] = backup_world_data(world_path, server_backup_dir, world_name)
         logger.info("World backup completed.")
-    except BackupWorldError as e:
-        # Log the specific error and re-raise as BackupWorldError to signal overall failure
-        logger.error(
-            f"Full backup failed: World backup step failed for server '{server_name}'. Error: {e}",
-            exc_info=True,
-        )
-        raise BackupWorldError(
-            f"World backup failed during full backup of '{server_name}'."
-        ) from e
-    except Exception as e:  # Catch unexpected errors during world backup step
-        logger.error(
-            f"Full backup failed: Unexpected error during world backup step for server '{server_name}'. Error: {e}",
-            exc_info=True,
-        )
-        raise BackupWorldError(
-            f"Unexpected error during world backup of '{server_name}'."
-        ) from e
+    except Exception as e: # Catching broader exceptions here for the component
+        logger.error(f"World backup failed for server '{server_name}': {e}", exc_info=True)
+        backup_results["world"] = None
+        # Depending on desired atomicity, you might choose to raise BackupWorldError here
+        # and halt, or continue with configs. Current approach: continue.
 
     # 2. Backup Configuration Files
     config_files_to_backup = ["allowlist.json", "permissions.json", "server.properties"]
-    failed_configs = []
-    for config_file in config_files_to_backup:
-        logger.info(f"Backing up config file: '{config_file}'...")
-        try:
-            # Check if file exists before attempting backup to avoid unnecessary errors if optional files are missing
-            full_config_path = os.path.join(
-                effective_base_dir, server_name, config_file
-            )
-            if os.path.exists(full_config_path):
-                backup_server(
-                    server_name,
-                    "config",
-                    effective_base_dir,
-                    file_to_backup=config_file,
+    for config_file_name in config_files_to_backup:
+        logger.info(f"Backing up config file: '{config_file_name}'...")
+        full_config_path = os.path.join(base_dir, server_name, config_file_name)
+        if os.path.exists(full_config_path):
+            try:
+                backup_results[config_file_name] = backup_single_config_file(
+                    full_config_path, server_backup_dir
                 )
-                logger.info(f"Config file '{config_file}' backup completed.")
-            else:
-                logger.warning(
-                    f"Config file '{config_file}' not found for server '{server_name}'. Skipping backup for this file."
+                logger.info(f"Config file '{config_file_name}' backup completed.")
+            except Exception as e:
+                logger.error(
+                    f"Failed to back up config file '{config_file_name}' for server '{server_name}': {e}",
+                    exc_info=True,
                 )
-        except FileOperationError as e:
-            logger.error(
-                f"Failed to back up config file '{config_file}' for server '{server_name}': {e}",
-                exc_info=True,
+                backup_results[config_file_name] = None
+        else:
+            logger.warning(
+                f"Config file '{config_file_name}' not found for server '{server_name}'. Skipping backup for this file."
             )
-            failed_configs.append(config_file)
-        except Exception as e:  # Catch unexpected errors during this config backup
-            logger.error(
-                f"Unexpected error backing up config file '{config_file}' for server '{server_name}': {e}",
-                exc_info=True,
-            )
-            failed_configs.append(config_file)
+            backup_results[config_file_name] = None # Explicitly mark as not backed up / skipped
 
-    # Report overall success or partial failure
-    if failed_configs:
-        error_msg = f"Full backup completed with errors. Failed to back up config file(s): {', '.join(failed_configs)}."
-        logger.error(error_msg)
-        # Raise FileOperationError to indicate partial failure
-        raise FileOperationError(error_msg)
-    else:
-        logger.info(f"Full backup completed successfully for server: '{server_name}'.")
+    if all(value is None for value in backup_results.values() if value is not None): # if all attempted backups failed
+        if backup_results.get("world") is None and "world" in backup_results: # Check if world backup was attempted and failed
+             raise BackupWorldError(f"Core world backup failed for '{server_name}' and no other components succeeded.")
 
 
-def restore_config_file(backup_file_path: str, server_dir: str) -> None:
+    return backup_results
+
+
+def restore_config_file_data(backup_file_path: str, server_dir: str) -> str:
     """
     Restores a single configuration file from a backup copy to the server directory.
-
-    Determines the original filename based on the backup filename pattern
-    (e.g., 'server_backup_TIMESTAMP.properties' -> 'server.properties').
+    Returns the path of the restored file.
 
     Args:
         backup_file_path: The full path to the backup file.
         server_dir: The full path to the target server's base directory.
+
+    Returns:
+        The full path of the file that was restored in the server directory.
 
     Raises:
         MissingArgumentError: If `backup_file_path` or `server_dir` is empty.
@@ -549,12 +389,12 @@ def restore_config_file(backup_file_path: str, server_dir: str) -> None:
 
     if not os.path.exists(backup_file_path):
         raise FileNotFoundError(f"Backup file not found: '{backup_file_path}'")
-    if not os.path.isdir(server_dir):
-        raise FileOperationError(
-            f"Target server directory does not exist or is not a directory: '{server_dir}'"
-        )
+    if not os.path.isdir(server_dir): # server_dir must exist for restore
+        os.makedirs(server_dir, exist_ok=True) # Create if not exists
+        # raise FileOperationError(
+        #     f"Target server directory does not exist or is not a directory: '{server_dir}'"
+        # )
 
-    # Extract original filename (e.g., server.properties from server_backup_....properties)
     match = re.match(r"^(.*?)_backup_\d{8}_\d{6}(\..*)$", backup_filename)
     if not match:
         error_msg = f"Could not determine original filename from backup file format: '{backup_filename}'"
@@ -570,9 +410,9 @@ def restore_config_file(backup_file_path: str, server_dir: str) -> None:
         f"Restoring '{backup_filename}' as '{target_filename}' in '{server_dir}'..."
     )
     try:
-        # copy2 preserves metadata
         shutil.copy2(backup_file_path, target_file_path)
         logger.info(f"Successfully restored config file to: {target_file_path}")
+        return target_file_path
     except OSError as e:
         logger.error(
             f"Failed to copy backup file '{backup_filename}' to '{target_file_path}': {e}",
@@ -583,158 +423,52 @@ def restore_config_file(backup_file_path: str, server_dir: str) -> None:
         ) from e
 
 
-def restore_server(
-    server_name: str, backup_file_path: str, restore_type: str, base_dir: str
-) -> None:
-    """
-    Manages the restoration process for either a server's world or a config file.
-
-    Args:
-        server_name: The name of the target server.
-        backup_file_path: The full path to the backup file (.mcworld or config backup).
-        restore_type: The type of restoration ("world" or "config").
-        base_dir: The base directory containing all server installations.
-
-    Raises:
-        MissingArgumentError: If required arguments are empty.
-        InvalidInputError: If `restore_type` is not "world" or "config".
-        FileNotFoundError: If `backup_file_path` does not exist.
-        FileOperationError: If restoration fails (raised by delegates or path issues).
-        DirectoryError: If server directory structure is invalid.
-        AddonExtractError: If world restoration (unzipping) fails.
-        RestoreError: If world import fails for other reasons.
-    """
-    if not server_name:
-        raise MissingArgumentError("Server name cannot be empty.")
-    if not backup_file_path:
-        raise MissingArgumentError("Backup file path cannot be empty.")
-    if not restore_type:
-        raise MissingArgumentError("Restore type cannot be empty.")
-    if not base_dir:
-        raise MissingArgumentError("Base directory cannot be empty.")
-
-    # Normalize restore type
-    restore_type = restore_type.lower()
-    backup_filename = os.path.basename(backup_file_path)
-    logger.info(
-        f"Initiating '{restore_type}' restore for server '{server_name}' from '{backup_filename}'."
-    )
-
-    # Validate backup file existence early
-    if not os.path.exists(backup_file_path):
-        raise FileNotFoundError(f"Backup file not found: '{backup_file_path}'")
-
-    server_dir = os.path.join(base_dir, server_name)
-    # Ensure server directory exists for config restore target
-    if not os.path.isdir(server_dir):
-        logger.warning(f"Server directory '{server_dir}' does not exist...")
-        # Depending on strictness, could raise DirectoryError here.
-
-    if restore_type == "world":
-        logger.debug("Delegating to world import function.")
-        try:
-            # world.import_world handles finding world name, extracting, etc.
-            world.import_world(
-                server_name, backup_file_path, base_dir
-            )  # Raises various errors
-            logger.info(
-                f"World restore from '{backup_filename}' completed successfully for server '{server_name}'."
-            )
-        except (
-            AddonExtractError,
-            FileOperationError,
-            DirectoryError,
-            RestoreError,
-        ) as e:
-            logger.error(
-                f"World restore failed for server '{server_name}' from '{backup_filename}': {e}",
-                exc_info=True,
-            )
-            raise  # Re-raise specific error from import_world
-        except Exception as e:
-            logger.error(
-                f"Unexpected error during world restore for '{server_name}': {e}",
-                exc_info=True,
-            )
-            raise RestoreError(
-                f"Unexpected world restore error for '{server_name}': {e}"
-            ) from e
-
-    elif restore_type == "config":
-        logger.debug("Delegating to config restore function.")
-        try:
-            restore_config_file(
-                backup_file_path, server_dir
-            )  # Raises FileNotFoundError, FileOperationError, InvalidInputError
-            # Success message is logged within restore_config_file
-        except (FileNotFoundError, FileOperationError, InvalidInputError) as e:
-            logger.error(
-                f"Config restore failed for server '{server_name}' from '{backup_filename}': {e}",
-                exc_info=True,
-            )
-            raise FileOperationError(
-                f"Config restore failed for '{backup_filename}': {e}"
-            ) from e  # Wrap as FileOperationError for consistency? Or keep original? Let's keep original.
-            # raise e
-        except Exception as e:
-            logger.error(
-                f"Unexpected error during config restore for '{server_name}': {e}",
-                exc_info=True,
-            )
-            raise FileOperationError(
-                f"Unexpected config restore error for '{server_name}': {e}"
-            ) from e
-    else:
-        logger.error(
-            f"Invalid restore type provided: '{restore_type}'. Must be 'world' or 'config'."
-        )
-        raise InvalidInputError(f"Invalid restore type: {restore_type}")
-
-
-def restore_all(server_name: str, base_dir: Optional[str] = None) -> None:
+def restore_all_server_data(server_name: str, base_dir: str) -> Dict[str, Optional[str]]:
     """
     Restores a server to its latest backed-up state (world and config files).
-
-    Finds the newest backup file for the world and each standard configuration
-    file within the server's backup directory and restores them.
+    Returns a dictionary of restored components and their original paths, or None if failed.
 
     Args:
         server_name: The name of the server to restore.
-        base_dir: Optional. The base directory containing all server installations.
-                  Defaults to the value from application settings if None.
+        base_dir: The base directory containing all server installations.
+
+    Returns:
+        A dictionary mapping component type (e.g., "world", "server.properties")
+        to the path where it was restored in the server directory, or None if failed.
 
     Raises:
-        MissingArgumentError: If `server_name` is empty.
-        RestoreError: If any restore operation (world or config) fails. The function
-                      attempts all restores even if one fails, but raises at the end
-                      if any failures occurred.
+        MissingArgumentError: If `server_name` or `base_dir` is empty.
         FileOperationError: If the server's backup directory cannot be accessed, or
                             if the BASE_DIR/BACKUP_DIR settings are missing.
+        RestoreError: If any critical restore operation fails.
     """
     if not server_name:
-        raise MissingArgumentError("Server name cannot be empty for restore_all.")
+        raise MissingArgumentError("Server name cannot be empty for restore_all_server_data.")
+    if not base_dir:
+        raise MissingArgumentError("Base directory cannot be empty for restore_all_server_data.")
 
-    effective_base_dir = base_dir if base_dir is not None else settings.get("BASE_DIR")
+
     backup_base_dir = settings.get("BACKUP_DIR")
-
-    if not effective_base_dir:
-        raise FileOperationError("BASE_DIR setting is missing or empty.")
     if not backup_base_dir:
         raise FileOperationError("BACKUP_DIR setting is missing or empty.")
 
     server_backup_dir = os.path.join(backup_base_dir, server_name)
+    server_install_dir = os.path.join(base_dir, server_name)
+
     logger.info(
-        f"Starting restore_all process for server '{server_name}' from backups in '{server_backup_dir}'."
+        f"Starting restore_all process for server '{server_name}' from backups in '{server_backup_dir}' to '{server_install_dir}'."
     )
 
     if not os.path.isdir(server_backup_dir):
         logger.warning(
             f"No backup directory found for server '{server_name}' at '{server_backup_dir}'. Cannot restore."
         )
-        # Return gracefully if no backups exist for the server
-        return
+        return {} # Return empty if no backup dir
 
-    failures = []  # Keep track of failed restore operations
+    os.makedirs(server_install_dir, exist_ok=True) # Ensure server install dir exists
+
+    restore_results: Dict[str, Optional[str]] = {}
+    failures = []
 
     # 1. Restore World (Latest .mcworld)
     try:
@@ -745,63 +479,79 @@ def restore_all(server_name: str, base_dir: Optional[str] = None) -> None:
             logger.info(
                 f"Found latest world backup: {os.path.basename(latest_world_backup)}"
             )
-            restore_server(
-                server_name, latest_world_backup, "world", effective_base_dir
+            # core_world.import_world returns the name of the imported world directory
+            imported_world_name = core_world.import_world(
+                server_name, latest_world_backup, base_dir
             )
+            restore_results["world"] = os.path.join(server_install_dir, "worlds", imported_world_name)
         else:
             logger.info("No .mcworld backup files found. Skipping world restore.")
+            restore_results["world"] = None
     except Exception as e:
         logger.error(
             f"Failed to restore world for server '{server_name}': {e}", exc_info=True
         )
-        failures.append(f"World ({e})")
+        failures.append(f"World ({type(e).__name__})")
+        restore_results["world"] = None
+
 
     # 2. Restore Config Files (Latest of each type)
-    config_patterns = {
-        "server.properties": os.path.join(
-            server_backup_dir, "server_backup_*.properties"
-        ),
-        "allowlist.json": os.path.join(server_backup_dir, "allowlist_backup_*.json"),
-        "permissions.json": os.path.join(
-            server_backup_dir, "permissions_backup_*.json"
-        ),
+    config_file_map = { # maps original name to backup prefix
+        "server.properties": "server_backup_",
+        "allowlist.json": "allowlist_backup_",
+        "permissions.json": "permissions_backup_",
     }
 
-    for config_type, pattern in config_patterns.items():
+    for original_filename, backup_prefix in config_file_map.items():
+        name_part, ext_part = os.path.splitext(original_filename)
+        pattern = os.path.join(server_backup_dir, f"{backup_prefix}*{ext_part}")
         try:
             logger.debug(
-                f"Searching for latest '{config_type}' backup (pattern: '{os.path.basename(pattern)}')..."
+                f"Searching for latest '{original_filename}' backup (pattern: '{os.path.basename(pattern)}')..."
             )
             config_backups = glob.glob(pattern)
-            if config_backups:
-                latest_config_backup = max(config_backups, key=os.path.getmtime)
+            # Further filter to ensure the prefix matches correctly before the timestamp part
+            # e.g. world_backup_....json should not match permissions_backup_....json
+            # This regex is basic, might need refinement for complex prefixes
+            valid_config_backups = [
+                b_path for b_path in config_backups
+                if re.match(f"^{re.escape(name_part)}_backup_\\d{{8}}_\\d{{6}}{re.escape(ext_part)}$", os.path.basename(b_path))
+            ]
+
+            if valid_config_backups:
+                latest_config_backup = max(valid_config_backups, key=os.path.getmtime)
                 logger.info(
-                    f"Found latest '{config_type}' backup: {os.path.basename(latest_config_backup)}"
+                    f"Found latest '{original_filename}' backup: {os.path.basename(latest_config_backup)}"
                 )
-                restore_server(
-                    server_name, latest_config_backup, "config", effective_base_dir
+                restored_path = restore_config_file_data(
+                    latest_config_backup, server_install_dir
                 )
+                restore_results[original_filename] = restored_path
             else:
                 logger.info(
-                    f"No backup found for '{config_type}'. Skipping restore for this file."
+                    f"No backup found for '{original_filename}'. Skipping restore for this file."
                 )
+                restore_results[original_filename] = None
         except Exception as e:
             logger.error(
-                f"Failed to restore '{config_type}' for server '{server_name}': {e}",
+                f"Failed to restore '{original_filename}' for server '{server_name}': {e}",
                 exc_info=True,
             )
-            failures.append(f"{config_type} ({e})")
+            failures.append(f"{original_filename} ({type(e).__name__})")
+            restore_results[original_filename] = None
 
-    # 3. Report final status
+
     if failures:
         error_summary = ", ".join(failures)
         logger.error(
-            f"Restore process for server '{server_name}' completed with errors. Failed components: {error_summary}"
+            f"Restore_all_server_data for server '{server_name}' completed with errors. Failed components: {error_summary}"
         )
+        # Raise a comprehensive error if any part failed
         raise RestoreError(
             f"Restore failed for server '{server_name}'. Failed components: {error_summary}"
         )
-    else:
-        logger.info(
-            f"Restore process completed successfully for server '{server_name}'."
-        )
+
+    logger.info(
+        f"Restore_all_server_data process completed for server '{server_name}'."
+    )
+    return restore_results

--- a/src/bedrock_server_manager/core/server/server.py
+++ b/src/bedrock_server_manager/core/server/server.py
@@ -531,7 +531,15 @@ def start_server(server_name: str, server_path_override: Optional[str] = None) -
             )
             start_successful_method = "windows_process"
             logger.info(
-                f"Initiated server start process on Windows for '{server_name}'."
+                f"Exited named pipe cleaninly on Windows for '{server_name}'."
+            )
+
+            manage_server_config(
+                server_name,
+                "status",
+                "write",
+                "STOPPED",
+                config_dir=details["config_dir_base"],
             )
         except ServerStartError as e:
             logger.error(

--- a/src/bedrock_server_manager/core/server/server.py
+++ b/src/bedrock_server_manager/core/server/server.py
@@ -453,7 +453,7 @@ def start_server(server_name: str, server_path_override: Optional[str] = None) -
         if screen_cmd_path:
             logger.info("Starting server.")
             try:
-                system_linux.linux_start_server(server_name, details["server_dir"])
+                system_linux._linux_start_server(server_name, details["server_dir"])
                 start_successful_method = "screen"
             except (CommandNotFoundError, ServerStartError) as e:
                 logger.error(

--- a/src/bedrock_server_manager/core/server/server.py
+++ b/src/bedrock_server_manager/core/server/server.py
@@ -60,7 +60,7 @@ else:
 logger = logging.getLogger("bedrock_server_manager")
 
 
-# --- Helper function to replace BedrockServer.__init__ logic ---
+# --- Helper function ---
 def _get_server_details(
     server_name: str, server_path_override: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -101,7 +101,7 @@ def _get_server_details(
 
     config_dir_base = (
         settings._config_dir
-    )  # Assumes this exists and is set via settings.load()
+    )
     if not config_dir_base:
         raise FileOperationError(
             "Internal _config_dir setting is missing or empty. Ensure settings are loaded."

--- a/src/bedrock_server_manager/core/server/server.py
+++ b/src/bedrock_server_manager/core/server/server.py
@@ -2,9 +2,9 @@
 """
 Core module for managing Bedrock server instances.
 
-Provides the `BedrockServer` class to interact with running server processes
-(start, stop, status, commands) and standalone functions for installation,
-updates, configuration management (server.properties, JSON files), status checks,
+Provides standalone functions to interact with running server processes
+(start, stop, status, commands), and for installation, updates,
+configuration management (server.properties, JSON files), status checks,
 and validation.
 """
 
@@ -60,626 +60,717 @@ else:
 logger = logging.getLogger("bedrock_server_manager")
 
 
-class BedrockServer:
+# --- Helper function to replace BedrockServer.__init__ logic ---
+def _get_server_details(
+    server_name: str, server_path_override: Optional[str] = None
+) -> Dict[str, Any]:
     """
-    Represents and manages a specific Bedrock server instance.
+    Gathers and validates server paths and essential details.
+    This helper is used by functions that previously were methods of BedrockServer.
 
-    Handles starting, stopping, checking status, getting process information
-    (PID, CPU, memory, uptime), and sending commands to the running server process.
+    Args:
+        server_name: The name of the server.
+        server_path_override: Optional. The full path to the server executable.
+                              If None, it's inferred based on OS and server_dir.
 
-    Attributes:
-        server_name (str): The unique name identifier for the server.
-        server_dir (str): The base directory path for the server installation.
-        server_path (str): The full path to the server executable.
-        process: Platform-specific process handle (e.g., Popen object on Windows).
-                 May be None if not started by this instance or not applicable.
-        status (str): An internal indicator of the server's perceived state
-                      ("STOPPED", "STARTING", "RUNNING", "STOPPING", "ERROR").
-                      Note: For actual running status, use `is_running()`.
+    Returns:
+        A dictionary containing server details:
+        - server_name (str)
+        - base_dir (str): Base directory for all servers from settings.
+        - server_dir (str): Path to this specific server's installation directory.
+        - server_path (str): Full path to the server executable.
+        - config_dir_base (str): Base directory for all server configs from settings.
+        - server_config_dir (str): Path to this specific server's configuration directory.
+
+    Raises:
+        MissingArgumentError: If `server_name` is empty.
+        FileOperationError: If BASE_DIR or _config_dir setting is missing.
+        ServerNotFoundError: If the server executable cannot be found.
     """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty for server operations.")
 
-    def __init__(self, server_name: str, server_path: Optional[str] = None):
-        """
-        Initializes the BedrockServer object.
+    logger.debug(f"Getting details for server '{server_name}'")
 
-        Args:
-            server_name: The name of the server.
-            server_path: Optional. The full path to the server executable.
-                         If None, it's inferred based on OS and server_dir.
+    base_dir = settings.get("BASE_DIR")
+    if not base_dir:
+        raise FileOperationError(
+            "BASE_DIR setting is missing or empty in configuration."
+        )
+    server_dir = os.path.join(base_dir, server_name)
 
-        Raises:
-            MissingArgumentError: If `server_name` is empty.
-            FileOperationError: If BASE_DIR setting is missing.
-            ServerNotFoundError: If the server executable cannot be found at the
-                                 determined `server_path`.
-        """
-        if not server_name:
-            raise MissingArgumentError(
-                "Server name cannot be empty for BedrockServer initialization."
-            )
+    config_dir_base = (
+        settings._config_dir
+    )  # Assumes this exists and is set via settings.load()
+    if not config_dir_base:
+        raise FileOperationError(
+            "Internal _config_dir setting is missing or empty. Ensure settings are loaded."
+        )
+    server_config_dir = os.path.join(config_dir_base, server_name)
 
-        logger.debug(f"Initializing BedrockServer instance for '{server_name}'")
-        self.server_name = server_name
+    if server_path_override:
+        server_executable_path = server_path_override
+        logger.debug(f"Using provided server executable path: {server_executable_path}")
+    else:
+        exe_name = (
+            "bedrock_server.exe" if platform.system() == "Windows" else "bedrock_server"
+        )
+        server_executable_path = os.path.join(server_dir, exe_name)
+        logger.debug(f"Using default server executable path: {server_executable_path}")
 
-        base_dir = settings.get("BASE_DIR")
-        if not base_dir:
-            raise FileOperationError(
-                "BASE_DIR setting is missing or empty in configuration."
-            )
-        self.server_dir = os.path.join(base_dir, self.server_name)
+    # Validate existence of executable immediately
+    if not os.path.isfile(server_executable_path):
+        error_msg = f"Server executable not found at path: {server_executable_path}"
+        logger.error(error_msg)
+        raise ServerNotFoundError(error_msg)
 
-        config_dir = settings._config_dir
-        if not config_dir:
-            raise FileOperationError(
-                "CONFIG_DIR setting is missing or empty in configuration."
-            )
-        self.server_config_dir = os.path.join(config_dir, self.server_name)
+    return {
+        "server_name": server_name,
+        "base_dir": base_dir,
+        "server_dir": server_dir,
+        "server_path": server_executable_path,
+        "config_dir_base": config_dir_base,
+        "server_config_dir": server_config_dir,
+    }
 
-        if server_path:
-            self.server_path = server_path
-            logger.debug(f"Using provided server executable path: {self.server_path}")
-        else:
-            # Determine the executable name based on the platform
-            exe_name = (
-                "bedrock_server.exe"
-                if platform.system() == "Windows"
-                else "bedrock_server"
-            )
-            self.server_path = os.path.join(self.server_dir, exe_name)
-            logger.debug(f"Using default server executable path: {self.server_path}")
 
-        # Validate existence immediately on init
-        if not os.path.isfile(self.server_path):
-            error_msg = f"Server executable not found at path: {self.server_path}"
-            logger.error(error_msg)
-            raise ServerNotFoundError(error_msg)
+# --- Standalone functions replacing BedrockServer methods ---
 
-        self.process = None  # Platform specific process object (e.g., subprocess.Popen)
-        self.status = "STOPPED"  # Internal status tracking
-        logger.debug(
-            f"BedrockServer '{self.server_name}' initialized. Executable: {self.server_path}"
+
+def check_if_server_is_running(server_name: str) -> bool:
+    """
+    Checks if the server process associated with this name is currently running.
+    Equivalent to former BedrockServer.is_running().
+    """
+    if not server_name:
+        # Consistent with how _get_server_details handles server_name
+        raise MissingArgumentError("Server name cannot be empty.")
+
+    logger.debug(f"Checking running status for server '{server_name}'")
+    base_dir = settings.get("BASE_DIR")
+    if not base_dir:
+        raise FileOperationError(
+            "BASE_DIR setting is missing or empty in configuration."
         )
 
-    def is_running(self) -> bool:
-        """Checks if the server process associated with this name is currently running."""
-        logger.debug(f"Checking running status for server '{self.server_name}'")
-        # Relies on the system-specific implementation
-        is_running = system_base.is_server_running(
-            self.server_name, settings.get("BASE_DIR")
+    is_running_flag = system_base.is_server_running(server_name, base_dir)
+    logger.debug(f"Server '{server_name}' is_running result: {is_running_flag}")
+    return is_running_flag
+
+
+def get_server_pid(server_name: str) -> Optional[int]:
+    """
+    Gets the process ID (PID) of the running server, if found.
+    Equivalent to former BedrockServer.get_pid().
+    """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty.")
+    logger.debug(f"Attempting to get PID for server '{server_name}'")
+    base_dir = settings.get("BASE_DIR")
+    if not base_dir:
+        raise FileOperationError(
+            "BASE_DIR setting is missing or empty in configuration."
         )
-        logger.debug(f"Server '{self.server_name}' is_running result: {is_running}")
-        return is_running
 
-    def get_pid(self) -> Optional[int]:
-        """Gets the process ID (PID) of the running server, if found."""
-        logger.debug(f"Attempting to get PID for server '{self.server_name}'")
-        server_info = system_base._get_bedrock_process_info(
-            self.server_name, settings.get("BASE_DIR")
+    server_info = system_base._get_bedrock_process_info(server_name, base_dir)
+    pid = server_info.get("pid") if server_info else None
+    logger.debug(f"Server '{server_name}' PID: {pid}")
+    return pid
+
+
+def get_server_cpu_usage(server_name: str) -> Optional[float]:
+    """
+    Gets the current CPU usage percentage of the server process, if running.
+    Equivalent to former BedrockServer.get_cpu_usage().
+    """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty.")
+    logger.debug(f"Attempting to get CPU usage for server '{server_name}'")
+    base_dir = settings.get("BASE_DIR")
+    if not base_dir:
+        raise FileOperationError(
+            "BASE_DIR setting is missing or empty in configuration."
         )
-        pid = server_info.get("pid") if server_info else None
-        logger.debug(f"Server '{self.server_name}' PID: {pid}")
-        return pid
 
-    def get_cpu_usage(self) -> Optional[float]:
-        """Gets the current CPU usage percentage of the server process, if running."""
-        logger.debug(f"Attempting to get CPU usage for server '{self.server_name}'")
-        server_info = system_base._get_bedrock_process_info(
-            self.server_name, settings.get("BASE_DIR")
+    server_info = system_base._get_bedrock_process_info(server_name, base_dir)
+    cpu_usage = server_info.get("cpu_percent") if server_info else None
+    logger.debug(f"Server '{server_name}' CPU usage: {cpu_usage}%")
+    return cpu_usage
+
+
+def get_server_memory_usage(server_name: str) -> Optional[float]:
+    """
+    Gets the current memory usage (in MB) of the server process, if running.
+    Equivalent to former BedrockServer.get_memory_usage().
+    """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty.")
+    logger.debug(f"Attempting to get memory usage for server '{server_name}'")
+    base_dir = settings.get("BASE_DIR")
+    if not base_dir:
+        raise FileOperationError(
+            "BASE_DIR setting is missing or empty in configuration."
         )
-        cpu_usage = server_info.get("cpu_percent") if server_info else None
-        logger.debug(f"Server '{self.server_name}' CPU usage: {cpu_usage}%")
-        return cpu_usage
 
-    def get_memory_usage(self) -> Optional[float]:
-        """Gets the current memory usage (in MB) of the server process, if running."""
-        logger.debug(f"Attempting to get memory usage for server '{self.server_name}'")
-        server_info = system_base._get_bedrock_process_info(
-            self.server_name, settings.get("BASE_DIR")
+    server_info = system_base._get_bedrock_process_info(server_name, base_dir)
+    memory_usage = server_info.get("memory_mb") if server_info else None
+    logger.debug(f"Server '{server_name}' memory usage: {memory_usage} MB")
+    return memory_usage
+
+
+def get_server_uptime(server_name: str) -> Optional[float]:
+    """
+    Gets the server process uptime in seconds, if running.
+    Equivalent to former BedrockServer.get_uptime().
+    """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty.")
+    logger.debug(f"Attempting to get uptime for server '{server_name}'")
+    base_dir = settings.get("BASE_DIR")
+    if not base_dir:
+        raise FileOperationError(
+            "BASE_DIR setting is missing or empty in configuration."
         )
-        memory_usage = server_info.get("memory_mb") if server_info else None
-        logger.debug(f"Server '{self.server_name}' memory usage: {memory_usage} MB")
-        return memory_usage
 
-    def get_uptime(self) -> Optional[float]:
-        """Gets the server process uptime in seconds, if running."""
-        logger.debug(f"Attempting to get uptime for server '{self.server_name}'")
-        server_info = system_base._get_bedrock_process_info(
-            self.server_name, settings.get("BASE_DIR")
-        )
-        uptime = server_info.get("uptime") if server_info else None
-        logger.debug(f"Server '{self.server_name}' uptime: {uptime} seconds")
-        return uptime
+    server_info = system_base._get_bedrock_process_info(server_name, base_dir)
+    uptime = server_info.get("uptime") if server_info else None
+    logger.debug(f"Server '{server_name}' uptime: {uptime} seconds")
+    return uptime
 
-    def send_command(self, command: str) -> None:
-        """
-        Sends a command string to the running server process.
 
-        Implementation is platform-specific (screen on Linux, named pipes on Windows).
+def send_server_command(server_name: str, command: str) -> None:
+    """
+    Sends a command string to the running server process.
+    Implementation is platform-specific (screen on Linux, named pipes on Windows).
+    Equivalent to former BedrockServer.send_command().
 
-        Args:
-            command: The command string to send to the server console.
+    Args:
+        server_name: The name of the server.
+        command: The command string to send to the server console.
 
-        Raises:
-            MissingArgumentError: If `command` is empty.
-            ServerNotRunningError: If the server process cannot be found or communicated with.
-            SendCommandError: If there's a platform-specific error sending the command
-                              (e.g., pipe errors, screen errors).
-            CommandNotFoundError: If a required external command (like 'screen') is not found.
-            NotImplementedError: If the current OS is not supported.
-        """
-        if not command:
-            raise MissingArgumentError("Command cannot be empty.")
+    Raises:
+        MissingArgumentError: If `server_name` or `command` is empty.
+        ServerNotRunningError: If the server process cannot be found or communicated with.
+        SendCommandError: If there's a platform-specific error sending the command.
+        CommandNotFoundError: If a required external command (like 'screen') is not found.
+        NotImplementedError: If the current OS is not supported.
+        FileOperationError: If BASE_DIR setting is missing.
+    """
+    if not server_name:
+        raise MissingArgumentError("Server name cannot be empty for send_command.")
+    if not command:
+        raise MissingArgumentError("Command cannot be empty.")
 
-        # Check if running *before* attempting platform-specific methods
-        if not self.is_running():
-            # Use is_running() for consistency, though _get_bedrock_process_info is also checked later
-            logger.error(
-                f"Cannot send command to server '{self.server_name}': Server is not running."
-            )
-            raise ServerNotRunningError(f"Server '{self.server_name}' is not running.")
-
-        logger.info(f"Sending command '{command}' to server '{self.server_name}'...")
-
-        os_name = platform.system()
-        if os_name == "Linux":
-            screen_cmd_path = shutil.which("screen")
-            if not screen_cmd_path:
-                logger.error(
-                    "'screen' command not found. Cannot send command. Is 'screen' installed and in PATH?"
-                )
-                raise CommandNotFoundError(
-                    "screen", message="'screen' command not found. Is it installed?"
-                )
-
-            try:
-                # Use screen -S <session_name> -X stuff "command\n"
-                screen_session_name = f"bedrock-{self.server_name}"
-                # Ensure command ends with a newline for execution in screen
-                command_with_newline = (
-                    command if command.endswith("\n") else command + "\n"
-                )
-                process = subprocess.run(
-                    [
-                        screen_cmd_path,
-                        "-S",
-                        screen_session_name,
-                        "-X",
-                        "stuff",
-                        command_with_newline,
-                    ],
-                    check=True,  # Raise exception on non-zero exit code
-                    capture_output=True,  # Capture stdout/stderr
-                    text=True,  # Decode output as text
-                )
-                logger.debug(
-                    f"'screen' command executed successfully for server '{self.server_name}'. stdout: {process.stdout}, stderr: {process.stderr}"
-                )
-                logger.info(
-                    f"Sent command '{command}' to server '{self.server_name}' via screen."
-                )
-            except subprocess.CalledProcessError as e:
-                # Common error: screen session doesn't exist (server not running in expected screen)
-                if "No screen session found" in e.stderr:
-                    logger.error(
-                        f"Failed to send command: Screen session '{screen_session_name}' not found. Is the server running correctly in screen?"
-                    )
-                    raise ServerNotRunningError(
-                        f"Screen session '{screen_session_name}' not found."
-                    ) from e
-                else:
-                    logger.error(
-                        f"Failed to send command via screen: {e}. stderr: {e.stderr}",
-                        exc_info=True,
-                    )
-                    raise SendCommandError(
-                        f"Failed to send command via screen: {e}"
-                    ) from e
-            except (
-                FileNotFoundError
-            ):  # Should be caught by shutil.which check, but safeguard
-                logger.error("'screen' command not found unexpectedly.")
-                raise CommandNotFoundError(
-                    "screen", message="'screen' command not found."
-                ) from None
-
-        elif os_name == "Windows":
-            if not WINDOWS_IMPORTS_AVAILABLE:
-                logger.error(
-                    "Cannot send command on Windows: Required 'pywin32' module is not installed."
-                )
-                raise SendCommandError(
-                    "Cannot send command on Windows: 'pywin32' module not found."
-                )
-            pass
-
-            pipe_name = rf"\\.\pipe\BedrockServerPipe_{self.server_name}"
-            handle = win32file.INVALID_HANDLE_VALUE
-
-            try:
-                logger.debug(f"Attempting to connect to named pipe: {pipe_name}")
-                handle = win32file.CreateFile(
-                    pipe_name,
-                    win32file.GENERIC_WRITE,  # Access rights
-                    0,  # Share mode (0 for exclusive access)
-                    None,  # Security attributes
-                    win32file.OPEN_EXISTING,  # Open only if exists
-                    0,  # Flags and attributes
-                    None,  # Template file handle
-                )
-
-                # Check if CreateFile failed immediately
-                if handle == win32file.INVALID_HANDLE_VALUE:
-                    # This usually means the pipe doesn't exist (server not running or pipe not created)
-                    logger.error(
-                        f"Could not open named pipe '{pipe_name}'. Server might not be running or pipe setup failed. Error code: {pywintypes.GetLastError()}"
-                    )
-                    raise ServerNotRunningError(
-                        f"Could not connect to server pipe '{pipe_name}'."
-                    )
-
-                # Set pipe to message mode
-                win32pipe.SetNamedPipeHandleState(
-                    handle, win32pipe.PIPE_READMODE_MESSAGE, None, None
-                )
-
-                # Write command (ensure CRLF line ending)
-                command_bytes = (command + "\r\n").encode("utf-8")  # Use UTF-8 encoding
-                win32file.WriteFile(handle, command_bytes)
-                logger.info(
-                    f"Sent command '{command}' to server '{self.server_name}' via named pipe."
-                )
-
-            except pywintypes.error as e:
-                # Handle specific Windows errors
-                win_error_code = e.winerror
-                logger.error(
-                    f"Windows error sending command via pipe '{pipe_name}': Code {win_error_code} - {e}",
-                    exc_info=True,
-                )
-                if win_error_code == 2:  # ERROR_FILE_NOT_FOUND
-                    raise ServerNotRunningError(
-                        f"Pipe '{pipe_name}' does not exist. Server likely not running."
-                    ) from e
-                elif win_error_code == 231:  # ERROR_PIPE_BUSY
-                    raise SendCommandError(
-                        "All pipe instances are busy. Try again later."
-                    ) from e
-                elif win_error_code == 109:  # ERROR_BROKEN_PIPE
-                    raise SendCommandError(
-                        "Pipe connection broken (server may have closed it)."
-                    ) from e
-                else:
-                    raise SendCommandError(f"Windows error sending command: {e}") from e
-            except Exception as e:  # Catch other potential errors
-                logger.error(
-                    f"Unexpected error sending command via pipe '{pipe_name}': {e}",
-                    exc_info=True,
-                )
-                raise SendCommandError(f"Unexpected error sending command: {e}") from e
-            finally:
-                # Always ensure the handle is closed if it was opened
-                if handle != win32file.INVALID_HANDLE_VALUE:
-                    try:
-                        win32file.CloseHandle(handle)
-                        logger.debug(f"Closed named pipe handle for '{pipe_name}'.")
-                    except pywintypes.error as close_err:
-                        # Log error during close but don't mask original error if one occurred
-                        logger.warning(
-                            f"Error closing pipe handle for '{pipe_name}': {close_err}",
-                            exc_info=True,
-                        )
-        else:
-            logger.error(
-                f"Sending commands is not supported on this operating system: {os_name}"
-            )
-            raise NotImplementedError(f"Sending commands not supported on {os_name}")
-
-    def start(self) -> None:
-        """
-        Starts the Bedrock server process.
-
-        Uses systemd on Linux (if available, falling back to screen) or starts
-        directly on Windows. Manages internal status and waits for confirmation.
-
-        Raises:
-            ServerStartError: If the server is already running, if the OS is unsupported,
-                              or if the server fails to start within the timeout.
-            CommandNotFoundError: If required external commands (systemctl, screen) are missing.
-        """
-        if self.is_running():
-            logger.warning(
-                f"Attempted to start server '{self.server_name}' but it is already running."
-            )
-            # Decide if this should be an error or just a warning. Let's make it an error.
-            raise ServerStartError(f"Server '{self.server_name}' is already running.")
-
-        self.status = "STARTING"
-        manage_server_config(
-            self.server_name, "status", "write", self.status
-        )  # Update persistent status
-        logger.info(f"Attempting to start server '{self.server_name}'...")
-
-        os_name = platform.system()
-        start_successful_method = None
-
-        if os_name == "Linux":
-            # Try systemd first
-            systemctl_cmd_path = shutil.which("systemctl")
-            service_name = f"bedrock-{self.server_name}"
-            if systemctl_cmd_path:
-                logger.debug("Attempting to start server via systemd user service.")
-                try:
-                    # Check if service exists and is enabled before starting? Optional.
-                    process = subprocess.run(
-                        [systemctl_cmd_path, "--user", "start", service_name],
-                        check=True,
-                        capture_output=True,
-                        text=True,
-                    )
-                    logger.info(
-                        f"Successfully initiated start for systemd service '{service_name}'."
-                    )
-                    start_successful_method = "systemd"
-                except (
-                    FileNotFoundError
-                ):  # Should be caught by shutil.which, but safeguard
-                    logger.error("'systemctl' command not found unexpectedly.")
-                    start_successful_method = None  # Ensure it proceeds to fallback
-                except subprocess.CalledProcessError as e:
-                    logger.warning(
-                        f"Starting via systemctl failed (maybe service not found/enabled?): {e}. stderr: {e.stderr}",
-                        exc_info=True,
-                    )
-                    # Fall through to screen method
-            else:
-                logger.warning(
-                    "'systemctl' command not found. Cannot use systemd method."
-                )
-
-            # Fallback to screen if systemd didn't work or wasn't available
-            if start_successful_method != "systemd":
-                screen_cmd_path = shutil.which("screen")
-                if screen_cmd_path:
-                    logger.info("Falling back to starting server via 'screen'.")
-                    try:
-                        system_linux._systemd_start_server(
-                            self.server_name, self.server_dir
-                        )
-                        start_successful_method = "screen"
-                    except (CommandNotFoundError, ServerStartError) as e:
-                        logger.error(
-                            f"Failed to start server using screen method: {e}",
-                            exc_info=True,
-                        )
-                        # Let the final timeout handle the overall failure
-                    except Exception as e:
-                        logger.error(
-                            f"Unexpected error starting server via screen method: {e}",
-                            exc_info=True,
-                        )
-                else:
-                    logger.error("'screen' command not found. Cannot start server.")
-                    manage_server_config(self.server_name, "status", "write", "ERROR")
-                    raise CommandNotFoundError(
-                        "screen",
-                        message="'screen' command not found. Cannot start server.",
-                    )
-
-        elif os_name == "Windows":
-            logger.debug("Attempting to start server via Windows process creation.")
-            try:
-                # This function should return the Popen object or raise ServerStartError
-                self.process = system_windows._windows_start_server(
-                    self.server_name, self.server_dir, self.server_config_dir
-                )
-                start_successful_method = "windows_process"
-                logger.info(
-                    f"Initiated server start process on Windows for '{self.server_name}'."
-                )
-            except ServerStartError as e:
-                logger.error(
-                    f"Failed to start server process on Windows: {e}", exc_info=True
-                )
-                # Let the final timeout handle the overall failure
-            except Exception as e:
-                logger.error(
-                    f"Unexpected error starting server process on Windows: {e}",
-                    exc_info=True,
-                )
-
-        else:
-            logger.error(
-                f"Starting server is not supported on this operating system: {os_name}"
-            )
-            manage_server_config(self.server_name, "status", "write", "ERROR")
-            raise ServerStartError(f"Unsupported operating system: {os_name}")
-
-        # Wait for confirmation that the server is actually running
-        attempts = 0
-        # Make max_attempts configurable?
-        max_attempts = (
-            settings.get("SERVER_START_TIMEOUT_SEC", 60) // 2
-        )  # Use setting, default 60s, check every 2s
-        sleep_interval = 2
-
-        logger.info(
-            f"Waiting up to {max_attempts * sleep_interval} seconds for server '{self.server_name}' to start..."
-        )
-        while attempts < max_attempts:
-            if self.is_running():
-                self.status = "RUNNING"
-                manage_server_config(self.server_name, "status", "write", self.status)
-                logger.info(f"Server '{self.server_name}' started successfully.")
-                return  # Success!
-            logger.debug(
-                f"Waiting for server '{self.server_name}' to start... (Check {attempts + 1}/{max_attempts})"
-            )
-            time.sleep(sleep_interval)
-            attempts += 1
-
-        # If loop finishes without returning, the server failed to start
-        self.status = "ERROR"
-        manage_server_config(self.server_name, "status", "write", self.status)
+    if not check_if_server_is_running(server_name):
         logger.error(
-            f"Server '{self.server_name}' failed to confirm running status within the timeout ({max_attempts * sleep_interval} seconds)."
+            f"Cannot send command to server '{server_name}': Server is not running."
         )
-        raise ServerStartError(
-            f"Server '{self.server_name}' failed to start within the timeout."
-        )
+        raise ServerNotRunningError(f"Server '{server_name}' is not running.")
 
-    def stop(self) -> None:
-        """
-        Stops the Bedrock server process gracefully.
+    logger.info(f"Sending command '{command}' to server '{server_name}'...")
 
-        Sends a 'stop' command, waits for the process to terminate.
-        Uses systemd on Linux (if available/managed), otherwise uses screen/Windows methods.
+    os_name = platform.system()
+    if os_name == "Linux":
+        screen_cmd_path = shutil.which("screen")
+        if not screen_cmd_path:
+            logger.error(
+                "'screen' command not found. Cannot send command. Is 'screen' installed and in PATH?"
+            )
+            raise CommandNotFoundError(
+                "screen", message="'screen' command not found. Is it installed?"
+            )
 
-        Raises:
-            ServerStopError: If the server is not running, if the OS is unsupported,
-                             or if the server fails to stop within the timeout.
-            SendCommandError: If sending the initial 'stop' command fails.
-            CommandNotFoundError: If required external commands are missing.
-        """
-        if not self.is_running():
+        try:
+            screen_session_name = f"bedrock-{server_name}"
+            command_with_newline = command if command.endswith("\n") else command + "\n"
+            process = subprocess.run(
+                [
+                    screen_cmd_path,
+                    "-S",
+                    screen_session_name,
+                    "-X",
+                    "stuff",
+                    command_with_newline,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            logger.debug(
+                f"'screen' command executed successfully for server '{server_name}'. stdout: {process.stdout}, stderr: {process.stderr}"
+            )
             logger.info(
-                f"Attempted to stop server '{self.server_name}', but it is not currently running."
+                f"Sent command '{command}' to server '{server_name}' via screen."
             )
-            # Update status just in case config was out of sync
-            if manage_server_config(self.server_name, "status", "read") != "STOPPED":
-                manage_server_config(self.server_name, "status", "write", "STOPPED")
-            self.status = "STOPPED"
-            return  # Nothing to do
-
-        self.status = "STOPPING"
-        manage_server_config(self.server_name, "status", "write", self.status)
-        logger.info(f"Attempting to stop server '{self.server_name}'...")
-
-        os_name = platform.system()
-        stop_initiated = False
-
-        if os_name == "Linux":
-            # Try systemd first if it seems managed
-            systemctl_cmd_path = shutil.which("systemctl")
-            service_name = f"bedrock-{self.server_name}"
-            # Basic check: does the service file exist? A better check might involve `systemctl is-active` etc.
-            service_file_path = os.path.join(
-                os.path.expanduser("~/.config/systemd/user/"), f"{service_name}.service"
-            )
-
-            if systemctl_cmd_path and os.path.exists(service_file_path):
-                logger.debug("Attempting to stop server via systemd user service.")
-                try:
-                    process = subprocess.run(
-                        [systemctl_cmd_path, "--user", "stop", service_name],
-                        check=True,
-                        capture_output=True,
-                        text=True,
-                    )
-                    logger.info(
-                        f"Successfully initiated stop for systemd service '{service_name}'."
-                    )
-                    stop_initiated = True
-                except (
-                    FileNotFoundError
-                ):  # Should be caught by shutil.which, but safeguard
-                    logger.error("'systemctl' command not found unexpectedly.")
-                except subprocess.CalledProcessError as e:
-                    logger.warning(
-                        f"Stopping via systemctl failed (maybe service wasn't running under systemd?): {e}. stderr: {e.stderr}",
-                        exc_info=True,
-                    )
-                    # Fall through to screen/command method if systemd fails
+        except subprocess.CalledProcessError as e:
+            if "No screen session found" in e.stderr:
+                logger.error(
+                    f"Failed to send command: Screen session '{screen_session_name}' not found. Is the server running correctly in screen?"
+                )
+                raise ServerNotRunningError(
+                    f"Screen session '{screen_session_name}' not found."
+                ) from e
             else:
-                logger.debug(
-                    "Systemctl not found or service file doesn't exist. Will try sending 'stop' command directly."
+                logger.error(
+                    f"Failed to send command via screen: {e}. stderr: {e.stderr}",
+                    exc_info=True,
+                )
+                raise SendCommandError(f"Failed to send command via screen: {e}") from e
+        except FileNotFoundError:
+            logger.error("'screen' command not found unexpectedly.")
+            raise CommandNotFoundError(
+                "screen", message="'screen' command not found."
+            ) from None
+
+    elif os_name == "Windows":
+        if not WINDOWS_IMPORTS_AVAILABLE:
+            logger.error(
+                "Cannot send command on Windows: Required 'pywin32' module is not installed."
+            )
+            raise SendCommandError(
+                "Cannot send command on Windows: 'pywin32' module not found."
+            )
+
+        pipe_name = rf"\\.\pipe\BedrockServerPipe_{server_name}"
+        handle = win32file.INVALID_HANDLE_VALUE
+
+        try:
+            logger.debug(f"Attempting to connect to named pipe: {pipe_name}")
+            handle = win32file.CreateFile(
+                pipe_name,
+                win32file.GENERIC_WRITE,
+                0,
+                None,
+                win32file.OPEN_EXISTING,
+                0,
+                None,
+            )
+
+            if handle == win32file.INVALID_HANDLE_VALUE:
+                logger.error(
+                    f"Could not open named pipe '{pipe_name}'. Server might not be running or pipe setup failed. Error code: {pywintypes.GetLastError()}"
+                )
+                raise ServerNotRunningError(
+                    f"Could not connect to server pipe '{pipe_name}'."
                 )
 
-            # If systemd didn't work or wasn't used, try sending 'stop' command
-            if not stop_initiated:
+            win32pipe.SetNamedPipeHandleState(
+                handle, win32pipe.PIPE_READMODE_MESSAGE, None, None
+            )
+
+            command_bytes = (command + "\r\n").encode("utf-8")
+            win32file.WriteFile(handle, command_bytes)
+            logger.info(
+                f"Sent command '{command}' to server '{server_name}' via named pipe."
+            )
+
+        except pywintypes.error as e:
+            win_error_code = e.winerror
+            logger.error(
+                f"Windows error sending command via pipe '{pipe_name}': Code {win_error_code} - {e}",
+                exc_info=True,
+            )
+            if win_error_code == 2:
+                raise ServerNotRunningError(
+                    f"Pipe '{pipe_name}' does not exist. Server likely not running."
+                ) from e
+            elif win_error_code == 231:
+                raise SendCommandError(
+                    "All pipe instances are busy. Try again later."
+                ) from e
+            elif win_error_code == 109:
+                raise SendCommandError(
+                    "Pipe connection broken (server may have closed it)."
+                ) from e
+            else:
+                raise SendCommandError(f"Windows error sending command: {e}") from e
+        except Exception as e:
+            logger.error(
+                f"Unexpected error sending command via pipe '{pipe_name}': {e}",
+                exc_info=True,
+            )
+            raise SendCommandError(f"Unexpected error sending command: {e}") from e
+        finally:
+            if handle != win32file.INVALID_HANDLE_VALUE:
                 try:
-                    logger.info("Sending 'stop' command to server process...")
-                    self.send_command("stop")  # Use the instance method
-                    stop_initiated = True  # Command sent, now wait
-                except (
-                    SendCommandError,
-                    ServerNotRunningError,
-                    CommandNotFoundError,
-                ) as e:
-                    logger.error(
-                        f"Failed to send 'stop' command to server '{self.server_name}': {e}. Will attempt process termination.",
+                    win32file.CloseHandle(handle)
+                    logger.debug(f"Closed named pipe handle for '{pipe_name}'.")
+                except pywintypes.error as close_err:
+                    logger.warning(
+                        f"Error closing pipe handle for '{pipe_name}': {close_err}",
                         exc_info=True,
                     )
-                    # Proceed to wait loop anyway, maybe it's shutting down due to other reasons
+    else:
+        logger.error(
+            f"Sending commands is not supported on this operating system: {os_name}"
+        )
+        raise NotImplementedError(f"Sending commands not supported on {os_name}")
+
+
+def start_server(server_name: str, server_path_override: Optional[str] = None) -> None:
+    """
+    Starts the Bedrock server process.
+    Uses systemd on Linux (if available, falling back to screen) or starts
+    directly on Windows. Manages persistent status and waits for confirmation.
+    Equivalent to former BedrockServer.start().
+
+    Args:
+        server_name: The name of the server.
+        server_path_override: Optional. The full path to the server executable.
+
+    Raises:
+        ServerStartError: If the server is already running, if the OS is unsupported,
+                          or if the server fails to start within the timeout.
+        CommandNotFoundError: If required external commands (systemctl, screen) are missing.
+        ServerNotFoundError: If the server executable cannot be found.
+        MissingArgumentError: If server_name is empty.
+        FileOperationError: If essential settings (BASE_DIR, _config_dir) are missing.
+    """
+    details = _get_server_details(server_name, server_path_override)
+    # server_name is details["server_name"]
+    # server_dir = details["server_dir"]
+    # server_config_dir = details["server_config_dir"]
+    # config_dir_base = details["config_dir_base"] (used for manage_server_config)
+
+    if check_if_server_is_running(server_name):
+        logger.warning(
+            f"Attempted to start server '{server_name}' but it is already running."
+        )
+        raise ServerStartError(f"Server '{server_name}' is already running.")
+
+    manage_server_config(
+        server_name,
+        "status",
+        "write",
+        "STARTING",
+        config_dir=details["config_dir_base"],
+    )
+    logger.info(f"Attempting to start server '{server_name}'...")
+
+    os_name = platform.system()
+    start_successful_method = None
+
+    if os_name == "Linux":
+        systemctl_cmd_path = shutil.which("systemctl")
+        service_name = f"bedrock-{server_name}"
+        if systemctl_cmd_path:
+            logger.debug("Attempting to start server via systemd user service.")
+            try:
+                process = subprocess.run(
+                    [systemctl_cmd_path, "--user", "start", service_name],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                logger.info(
+                    f"Successfully initiated start for systemd service '{service_name}'."
+                )
+                start_successful_method = "systemd"
+            except FileNotFoundError:
+                logger.error("'systemctl' command not found unexpectedly.")
+                start_successful_method = None
+            except subprocess.CalledProcessError as e:
+                logger.warning(
+                    f"Starting via systemctl failed (maybe service not found/enabled?): {e}. stderr: {e.stderr}",
+                    exc_info=True,
+                )
+        else:
+            logger.warning("'systemctl' command not found. Cannot use systemd method.")
+
+        if start_successful_method != "systemd":
+            screen_cmd_path = shutil.which("screen")
+            if screen_cmd_path:
+                logger.info("Falling back to starting server via 'screen'.")
+                try:
+                    system_linux._systemd_start_server(
+                        server_name, details["server_dir"]
+                    )
+                    start_successful_method = "screen"
+                except (CommandNotFoundError, ServerStartError) as e:
+                    logger.error(
+                        f"Failed to start server using screen method: {e}",
+                        exc_info=True,
+                    )
                 except Exception as e:
                     logger.error(
-                        f"Unexpected error sending 'stop' command to server '{self.server_name}': {e}. Will attempt process termination.",
+                        f"Unexpected error starting server via screen method: {e}",
                         exc_info=True,
                     )
+            else:
+                logger.error("'screen' command not found. Cannot start server.")
+                manage_server_config(
+                    server_name,
+                    "status",
+                    "write",
+                    "ERROR",
+                    config_dir=details["config_dir_base"],
+                )
+                raise CommandNotFoundError(
+                    "screen", message="'screen' command not found. Cannot start server."
+                )
 
-        elif os_name == "Windows":
-            system_windows._windows_stop_server(
-                self.server_name, self.server_dir, self.server_config_dir
+    elif os_name == "Windows":
+        logger.debug("Attempting to start server via Windows process creation.")
+        try:
+            _ = system_windows._windows_start_server(  # Popen object not stored/used further here
+                server_name, details["server_dir"], details["server_config_dir"]
             )
-        else:
+            start_successful_method = "windows_process"
+            logger.info(
+                f"Initiated server start process on Windows for '{server_name}'."
+            )
+        except ServerStartError as e:
             logger.error(
-                f"Stopping server is not supported on this operating system: {os_name}"
+                f"Failed to start server process on Windows: {e}", exc_info=True
             )
-            manage_server_config(
-                self.server_name, "status", "write", "ERROR"
-            )  # Mark as error state
-            raise ServerStopError(f"Unsupported operating system: {os_name}")
-
-        # Wait for the server process to actually exit
-        attempts = 0
-        max_attempts = (
-            settings.get("SERVER_STOP_TIMEOUT_SEC", 60) // 2
-        )  # Use setting, default 60s, check every 2s
-        sleep_interval = 2
-        logger.info(
-            f"Waiting up to {max_attempts * sleep_interval} seconds for server '{self.server_name}' process to terminate..."
-        )
-
-        while attempts < max_attempts:
-            if not self.is_running():
-                self.status = "STOPPED"
-                manage_server_config(self.server_name, "status", "write", self.status)
-                logger.info(f"Server '{self.server_name}' stopped successfully.")
-                # Clean up screen session if it exists and wasn't managed by systemd
-                if (
-                    os_name == "Linux" and not stop_initiated
-                ):  # Or check if screen was used specifically
-                    screen_session_name = f"bedrock-{self.server_name}"
-                    try:
-                        subprocess.run(
-                            ["screen", "-S", screen_session_name, "-X", "quit"],
-                            check=False,
-                            capture_output=True,
-                        )
-                        logger.debug(
-                            f"Attempted to quit potentially lingering screen session '{screen_session_name}'."
-                        )
-                    except FileNotFoundError:
-                        pass  # Screen not found, already handled
-                return  # Success!
-
-            logger.debug(
-                f"Waiting for server '{self.server_name}' to stop... (Check {attempts + 1}/{max_attempts})"
+        except Exception as e:
+            logger.error(
+                f"Unexpected error starting server process on Windows: {e}",
+                exc_info=True,
             )
-            time.sleep(sleep_interval)
-            attempts += 1
 
-        # If loop finishes, server didn't stop gracefully
+    else:
         logger.error(
-            f"Server '{self.server_name}' failed to stop within the timeout ({max_attempts * sleep_interval} seconds). Process might still be running."
+            f"Starting server is not supported on this operating system: {os_name}"
         )
-        self.status = "ERROR"  # Mark as error state
-        manage_server_config(self.server_name, "status", "write", self.status)
-        raise ServerStopError(
-            f"Server '{self.server_name}' failed to stop within the timeout. Manual intervention may be required."
+        manage_server_config(
+            server_name,
+            "status",
+            "write",
+            "ERROR",
+            config_dir=details["config_dir_base"],
         )
+        raise ServerStartError(f"Unsupported operating system: {os_name}")
+
+    attempts = 0
+    max_attempts = settings.get("SERVER_START_TIMEOUT_SEC", 60) // 2
+    sleep_interval = 2
+
+    logger.info(
+        f"Waiting up to {max_attempts * sleep_interval} seconds for server '{server_name}' to start..."
+    )
+    while attempts < max_attempts:
+        if check_if_server_is_running(server_name):
+            manage_server_config(
+                server_name,
+                "status",
+                "write",
+                "RUNNING",
+                config_dir=details["config_dir_base"],
+            )
+            logger.info(f"Server '{server_name}' started successfully.")
+            return
+        logger.debug(
+            f"Waiting for server '{server_name}' to start... (Check {attempts + 1}/{max_attempts})"
+        )
+        time.sleep(sleep_interval)
+        attempts += 1
+
+    manage_server_config(
+        server_name, "status", "write", "ERROR", config_dir=details["config_dir_base"]
+    )
+    logger.error(
+        f"Server '{server_name}' failed to confirm running status within the timeout ({max_attempts * sleep_interval} seconds)."
+    )
+    raise ServerStartError(
+        f"Server '{server_name}' failed to start within the timeout."
+    )
 
 
-# --- Standalone Functions ---
+def stop_server(server_name: str, server_path_override: Optional[str] = None) -> None:
+    """
+    Stops the Bedrock server process gracefully.
+    Sends a 'stop' command, waits for the process to terminate.
+    Equivalent to former BedrockServer.stop().
+
+    Args:
+        server_name: The name of the server.
+        server_path_override: Optional. The full path to the server executable.
+
+    Raises:
+        ServerStopError: If the server is not running (when expected), OS unsupported,
+                         or fails to stop within timeout.
+        SendCommandError: If sending the initial 'stop' command fails.
+        CommandNotFoundError: If required external commands are missing.
+        ServerNotFoundError: If the server executable cannot be found (for checks).
+        MissingArgumentError: If server_name is empty.
+        FileOperationError: If essential settings (BASE_DIR, _config_dir) are missing.
+    """
+    # _get_server_details also validates executable existence, which is implicitly
+    # part of the original BedrockServer's state.
+    details = _get_server_details(server_name, server_path_override)
+    # server_name = details["server_name"]
+    # server_dir = details["server_dir"] (used by system_windows._windows_stop_server)
+    # server_config_dir = details["server_config_dir"] (used by system_windows._windows_stop_server)
+    # config_dir_base = details["config_dir_base"] (used for manage_server_config)
+
+    if not check_if_server_is_running(server_name):
+        logger.info(
+            f"Attempted to stop server '{server_name}', but it is not currently running."
+        )
+        if (
+            manage_server_config(
+                server_name, "status", "read", config_dir=details["config_dir_base"]
+            )
+            != "STOPPED"
+        ):
+            manage_server_config(
+                server_name,
+                "status",
+                "write",
+                "STOPPED",
+                config_dir=details["config_dir_base"],
+            )
+        return
+
+    manage_server_config(
+        server_name,
+        "status",
+        "write",
+        "STOPPING",
+        config_dir=details["config_dir_base"],
+    )
+    logger.info(f"Attempting to stop server '{server_name}'...")
+
+    os_name = platform.system()
+    stop_initiated_by_systemd = False  # Specific to systemd stop path
+
+    if os_name == "Linux":
+        systemctl_cmd_path = shutil.which("systemctl")
+        service_name = f"bedrock-{server_name}"
+        service_file_path = os.path.join(
+            os.path.expanduser("~/.config/systemd/user/"), f"{service_name}.service"
+        )
+
+        if systemctl_cmd_path and os.path.exists(service_file_path):
+            logger.debug("Attempting to stop server via systemd user service.")
+            try:
+                process = subprocess.run(
+                    [systemctl_cmd_path, "--user", "stop", service_name],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                logger.info(
+                    f"Successfully initiated stop for systemd service '{service_name}'."
+                )
+                stop_initiated_by_systemd = True
+            except FileNotFoundError:
+                logger.error("'systemctl' command not found unexpectedly.")
+            except subprocess.CalledProcessError as e:
+                logger.warning(
+                    f"Stopping via systemctl failed (maybe service wasn't running under systemd?): {e}. stderr: {e.stderr}",
+                    exc_info=True,
+                )
+        else:
+            logger.debug(
+                "Systemctl not found or service file doesn't exist. Will try sending 'stop' command directly."
+            )
+
+        if not stop_initiated_by_systemd:
+            try:
+                logger.info("Sending 'stop' command to server process...")
+                send_server_command(
+                    server_name, "stop"
+                )  # Uses the new standalone function
+                # If send_server_command succeeds, we consider stop initiated for the wait loop.
+            except (SendCommandError, ServerNotRunningError, CommandNotFoundError) as e:
+                logger.error(
+                    f"Failed to send 'stop' command to server '{server_name}': {e}. Will attempt process termination.",
+                    exc_info=True,
+                )
+            except Exception as e:  # Catch other errors from send_server_command
+                logger.error(
+                    f"Unexpected error sending 'stop' command to server '{server_name}': {e}. Will attempt process termination.",
+                    exc_info=True,
+                )
+
+    elif os_name == "Windows":
+        try:
+            system_windows._windows_stop_server(
+                server_name, details["server_dir"], details["server_config_dir"]
+            )
+            # Assume this function either succeeds in initiating stop or raises an error
+        except Exception as e:  # Catch errors from _windows_stop_server
+            logger.error(
+                f"Failed to stop server on Windows for '{server_name}': {e}",
+                exc_info=True,
+            )
+            # Depending on the error, we might want to raise or let the timeout handle it.
+            # For now, let the timeout proceed.
+            manage_server_config(
+                server_name,
+                "status",
+                "write",
+                "ERROR",
+                config_dir=details["config_dir_base"],
+            )
+            raise ServerStopError(
+                f"Failed to initiate stop for server '{server_name}' on Windows: {e}"
+            ) from e
+    else:
+        logger.error(
+            f"Stopping server is not supported on this operating system: {os_name}"
+        )
+        manage_server_config(
+            server_name,
+            "status",
+            "write",
+            "ERROR",
+            config_dir=details["config_dir_base"],
+        )
+        raise ServerStopError(f"Unsupported operating system: {os_name}")
+
+    attempts = 0
+    max_attempts = settings.get("SERVER_STOP_TIMEOUT_SEC", 60) // 2
+    sleep_interval = 2
+    logger.info(
+        f"Waiting up to {max_attempts * sleep_interval} seconds for server '{server_name}' process to terminate..."
+    )
+
+    while attempts < max_attempts:
+        if not check_if_server_is_running(server_name):
+            manage_server_config(
+                server_name,
+                "status",
+                "write",
+                "STOPPED",
+                config_dir=details["config_dir_base"],
+            )
+            logger.info(f"Server '{server_name}' stopped successfully.")
+            if os_name == "Linux" and not stop_initiated_by_systemd:
+                screen_session_name = f"bedrock-{server_name}"
+                try:
+                    subprocess.run(
+                        ["screen", "-S", screen_session_name, "-X", "quit"],
+                        check=False,
+                        capture_output=True,
+                    )
+                    logger.debug(
+                        f"Attempted to quit potentially lingering screen session '{screen_session_name}'."
+                    )
+                except FileNotFoundError:
+                    pass
+            return
+
+        logger.debug(
+            f"Waiting for server '{server_name}' to stop... (Check {attempts + 1}/{max_attempts})"
+        )
+        time.sleep(sleep_interval)
+        attempts += 1
+
+    logger.error(
+        f"Server '{server_name}' failed to stop within the timeout ({max_attempts * sleep_interval} seconds). Process might still be running."
+    )
+    manage_server_config(
+        server_name, "status", "write", "ERROR", config_dir=details["config_dir_base"]
+    )
+    raise ServerStopError(
+        f"Server '{server_name}' failed to stop within the timeout. Manual intervention may be required."
+    )
+
+
+# --- Existing Standalone Functions (Unchanged by BedrockServer class removal, but calls to its methods updated if any) ---
 
 
 def get_world_name(server_name: str, base_dir: str) -> str:
@@ -937,11 +1028,18 @@ def manage_server_config(
         logger.debug(f"Read operation: Key='{key}', Value='{read_value}'")
         return read_value
     elif operation == "write":
-        if value is None:
-            logger.warning(
-                f"Write operation called for key '{key}' but value is None. Writing None to config."
+        if (
+            value is None and key != "installed_version"
+        ):  # Allow writing None for some keys if explicitly intended, but 'value' itself is expected.
+            # This check was: if value is None: raise MissingArgumentError.
+            # Let's refine it: for write operations, value is generally expected.
+            # If a specific key *can* be None, the caller should pass None explicitly.
+            # The original raise MissingArgumentError("Value is required for 'write' operation.") is generally correct.
+            # The warning about writing None and then raising seems slightly contradictory.
+            # Let's stick to the original: value is required.
+            raise MissingArgumentError(
+                f"Value is required for 'write' operation on key '{key}'."
             )
-            raise MissingArgumentError("Value is required for 'write' operation.")
 
         logger.debug(f"Write operation: Key='{key}', New Value='{value}'")
         current_config[key] = value
@@ -1681,15 +1779,25 @@ def configure_permissions(
                     f"Updating permission for XUID '{xuid}' from '{entry.get('permission')}' to '{permission}'."
                 )
                 permissions_data[i]["permission"] = permission
-                if player_name and entry.get("name") != player_name:
+                if (
+                    player_name and entry.get("name") != player_name
+                ):  # Also update name if provided and different
                     logger.debug(f"Updating name for XUID '{xuid}' to '{player_name}'.")
                     permissions_data[i]["name"] = player_name
                 updated = True
             else:
-                logger.info(
-                    f"Player with XUID '{xuid}' already has permission '{permission}'. No changes needed."
-                )
-                updated = False  # Explicitly set updated to False if no change
+                # If permission is the same, check if name needs updating
+                if player_name and entry.get("name") != player_name:
+                    logger.info(
+                        f"Updating name for XUID '{xuid}' (permission unchanged) to '{player_name}'."
+                    )
+                    permissions_data[i]["name"] = player_name
+                    updated = True
+                else:
+                    logger.info(
+                        f"Player with XUID '{xuid}' already has permission '{permission}' and matching name (if provided). No changes needed."
+                    )
+                    # updated remains False if no changes were made
             break
 
     if not player_found:
@@ -1697,12 +1805,22 @@ def configure_permissions(
             logger.warning(
                 f"Adding new player with XUID '{xuid}' but no player_name provided. Using XUID as name."
             )
-            player_name = xuid  # Use XUID as fallback name
+            # Consider if using XUID as name is the best default or if player_name should be mandatory for new entries.
+            # For now, matching original behavior: if player_name is None, it implies it might not be set.
+            # However, the JSON structure seems to always have a name.
+            # Let's ensure 'name' is always present in the new entry.
+            effective_player_name = player_name if player_name is not None else xuid
+        else:
+            effective_player_name = player_name
 
         logger.info(
-            f"Adding new player XUID '{xuid}' (Name: '{player_name}') with permission '{permission}'."
+            f"Adding new player XUID '{xuid}' (Name: '{effective_player_name}') with permission '{permission}'."
         )
-        new_entry = {"permission": permission, "xuid": xuid, "name": player_name}
+        new_entry = {
+            "permission": permission,
+            "xuid": xuid,
+            "name": effective_player_name,
+        }
         permissions_data.append(new_entry)
         updated = True
 
@@ -1849,9 +1967,16 @@ def _write_version_config(
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
 
-    if not installed_version:
-        logger.warning(f"Empty installed_version for server '{server_name}' provided.")
-        raise InvalidInputError("installed_version required")
+    if (
+        not installed_version
+    ):  # installed_version itself should not be empty string if it's a valid version
+        logger.warning(
+            f"Empty installed_version for server '{server_name}' provided to _write_version_config."
+        )
+        # Depending on policy, this could be an error or default to "UNKNOWN"
+        raise InvalidInputError(
+            "installed_version cannot be empty when writing to config."
+        )
 
     logger.debug(
         f"Writing installed_version '{installed_version}' to config for server '{server_name}'."
@@ -1861,7 +1986,7 @@ def _write_version_config(
             server_name=server_name,
             key="installed_version",
             operation="write",
-            value=installed_version,  # Value can be None or empty string based on check above
+            value=installed_version,
             config_dir=config_dir,
         )
         logger.debug("Successfully wrote installed_version to config.")
@@ -1931,8 +2056,16 @@ def install_server(
     if is_update:
         try:
             # This function stops the server if running and returns True if it was running
-            was_running = stop_server_if_running(server_name, base_dir)
-        except (InvalidServerNameError, ServerStopError, CommandNotFoundError) as e:
+            was_running = stop_server_if_running(
+                server_name, base_dir
+            )  # Updated to use standalone
+        except (
+            ServerNotFoundError,
+            InvalidServerNameError,
+            ServerStopError,
+            CommandNotFoundError,
+            SendCommandError,
+        ) as e:
             # Abort the update if stopping fails, as extraction might fail otherwise.
             logger.error(
                 f"Failed to stop server '{server_name}' before update: {e}. Aborting update.",
@@ -1985,7 +2118,7 @@ def install_server(
         DownloadExtractError,
         FileOperationError,
         MissingArgumentError,
-        FileNotFoundError,
+        FileNotFoundError,  # Though zip_file_path should be checked by caller usually
     ) as e:
         logger.error(
             f"Failed to extract server files for '{server_name}': {e}", exc_info=True
@@ -2020,18 +2153,23 @@ def install_server(
         f"Writing installed version '{target_version}' to config for server '{server_name}'."
     )
     try:
+        # _config_dir for _write_version_config will be fetched from settings by manage_server_config
         _write_version_config(server_name, target_version)
         manage_server_config(
             server_name, "status", "write", "STOPPED"
         )  # Set status to STOPPED after install/update
         logger.debug("Successfully wrote version and updated status in config.")
-    except (FileOperationError, InvalidServerNameError) as e:
+    except (
+        FileOperationError,
+        InvalidServerNameError,
+        InvalidInputError,
+    ) as e:  # InvalidInputError from _write_version_config
         # If writing config fails, the server might work but manager won't know version/status.
         logger.error(
             f"Failed to write version/status to config file for '{server_name}': {e}. Installation complete but metadata missing.",
             exc_info=True,
         )
-        raise FileOperationError(
+        raise FileOperationError(  # Re-raise as FileOperationError for consistency with original intent
             f"Failed to write version/status config for '{server_name}'."
         ) from e
 
@@ -2041,9 +2179,15 @@ def install_server(
             f"Attempting to restart server '{server_name}' as it was running before update..."
         )
         try:
-            start_server_if_was_running(server_name, base_dir, was_running)
+            start_server_if_was_running(
+                server_name, base_dir, was_running
+            )  # Updated to use standalone
             logger.info(f"Server '{server_name}' restart initiated.")
-        except (ServerStartError, CommandNotFoundError) as e:
+        except (
+            ServerStartError,
+            CommandNotFoundError,
+            ServerNotFoundError,
+        ) as e:  # ServerNotFoundError from _get_server_details
             # Log error but installation itself was successful
             logger.error(
                 f"Installation/update complete, but failed to automatically restart server '{server_name}': {e}. Please start it manually.",
@@ -2083,7 +2227,9 @@ def no_update_needed(
         # (InternetConnectivityError, DownloadExtractError, OSError)
     """
     if not server_name:
-        raise InvalidServerNameError("Server name cannot be empty.")
+        raise InvalidServerNameError(
+            "Server name cannot be empty."
+        )  # Or MissingArgumentError
 
     target_upper = target_version_spec.upper()
 
@@ -2158,7 +2304,7 @@ def delete_server_data(
         MissingArgumentError: If `server_name` or `base_dir` is empty.
         InvalidServerNameError: If `server_name` is invalid.
         DirectoryError: If deleting the server data or config directories fails.
-        FileOperationError: If settings (BACKUP_DIR) are missing.
+        FileOperationError: If settings (BACKUP_DIR, _config_dir) are missing.
     """
     if not server_name:
         raise InvalidServerNameError("Server name cannot be empty.")
@@ -2202,19 +2348,19 @@ def delete_server_data(
             logger.info(
                 f"Server '{server_name}' is running. Attempting to stop before deletion..."
             )
-            # Use BedrockServer class to handle stop logic
-            server_instance = BedrockServer(
-                server_name
-            )  # Assumes executable exists if running
-            server_instance.stop()  # Raises ServerStopError on failure
+            stop_server(server_name)  # Use standalone function
             logger.info(f"Server '{server_name}' stopped successfully.")
         else:
             logger.debug(f"Server '{server_name}' is not running.")
-    except ServerNotFoundError:
+    except ServerNotFoundError:  # Raised by _get_server_details if exe is already gone
         logger.debug(
-            "Server executable not found, cannot use BedrockServer class to stop. Proceeding with deletion."
+            "Server executable not found, cannot use stop_server standard procedure. Proceeding with deletion of remaining files."
         )
-    except (ServerStopError, CommandNotFoundError) as e:
+    except (
+        ServerStopError,
+        CommandNotFoundError,
+        SendCommandError,
+    ) as e:  # Errors from stop_server
         logger.error(
             f"Failed to stop server '{server_name}' before deletion: {e}. Deletion aborted.",
             exc_info=True,
@@ -2222,7 +2368,7 @@ def delete_server_data(
         raise DirectoryError(
             f"Failed to stop running server '{server_name}' before deletion."
         ) from e
-    except Exception as e:
+    except Exception as e:  # Other unexpected errors
         logger.error(
             f"Unexpected error stopping server '{server_name}' before deletion: {e}. Deletion aborted.",
             exc_info=True,
@@ -2333,27 +2479,28 @@ def delete_server_data(
             f"Failed to completely delete server '{server_name}'. Failed items: {error_summary}"
         )
     else:
-        logger.debug(f"Successfully deleted all data for server: '{server_name}'.")
+        logger.info(f"Successfully deleted all data for server: '{server_name}'.")
 
 
-# --- Helper Functions for Start/Stop Logic ---
+# --- Helper Functions for Start/Stop Logic (Updated to use standalone server functions) ---
 
 
 def start_server_if_was_running(
-    server_name: str, base_dir: str, was_running: bool
+    server_name: str,
+    base_dir: str,
+    was_running: bool,  # base_dir might be redundant if start_server fetches it
 ) -> None:
     """
-    Starts the server using the BedrockServer class, but only if `was_running` is True.
-
-    Helper function primarily for use after updates/installs.
+    Starts the server using the standalone `start_server` function,
+    but only if `was_running` is True.
 
     Args:
         server_name: The name of the server.
-        base_dir: The base directory containing the server folder.
+        base_dir: The base directory (primarily for context, start_server derives paths itself).
         was_running: Boolean indicating if the server was running prior to an operation.
 
     Raises:
-        # Propagates exceptions from BedrockServer.start()
+        # Propagates exceptions from start_server()
         ServerStartError, CommandNotFoundError, ServerNotFoundError, etc.
     """
     if was_running:
@@ -2361,23 +2508,20 @@ def start_server_if_was_running(
             f"Server '{server_name}' was running previously. Attempting to restart..."
         )
         try:
-            # Create instance and start it
-            server_instance = BedrockServer(
-                server_name
-            )  # Assumes server executable exists now
-            server_instance.start()
+            start_server(server_name)  # Standalone function
             logger.info(f"Server '{server_name}' restart initiated successfully.")
         except (ServerNotFoundError, ServerStartError, CommandNotFoundError) as e:
             logger.error(
                 f"Failed to automatically restart server '{server_name}': {e}. Please start it manually.",
                 exc_info=True,
             )
-            raise  # Re-raise the specific error from start()
+            raise
         except Exception as e:
             logger.error(
                 f"Unexpected error automatically restarting server '{server_name}': {e}. Please start it manually.",
                 exc_info=True,
             )
+            # Wrap unexpected errors in ServerStartError for consistency if desired
             raise ServerStartError(
                 f"Unexpected error restarting server '{server_name}': {e}"
             ) from e
@@ -2389,18 +2533,19 @@ def start_server_if_was_running(
 
 def stop_server_if_running(server_name: str, base_dir: str) -> bool:
     """
-    Checks if a server is running and stops it if it is.
+    Checks if a server is running (using system_base) and stops it using the
+    standalone `stop_server` function if it is.
 
     Args:
         server_name: The name of the server.
-        base_dir: The base directory containing the server folder.
+        base_dir: The base directory (used for the initial is_server_running check).
 
     Returns:
         True if the server was running (and a stop was attempted), False otherwise.
 
     Raises:
         InvalidServerNameError: If `server_name` is empty.
-        # Propagates exceptions from BedrockServer.stop() if stopping fails
+        # Propagates exceptions from stop_server() if stopping fails
         ServerStopError, SendCommandError, CommandNotFoundError, ServerNotFoundError, etc.
     """
     if not server_name:
@@ -2409,41 +2554,42 @@ def stop_server_if_running(server_name: str, base_dir: str) -> bool:
     logger.debug(f"Checking if server '{server_name}' needs to be stopped...")
 
     try:
-        # Check running status first
+        # Use system_base.is_server_running for the initial check as it's lightweight
         if system_base.is_server_running(server_name, base_dir):
             logger.info(f"Server '{server_name}' is running. Attempting to stop...")
             try:
-                # Use BedrockServer class to handle stop logic
-                server_instance = BedrockServer(
-                    server_name
-                )  # Raises ServerNotFoundError if exe missing
-                server_instance.stop()  # Raises ServerStopError etc. on failure
+                stop_server(server_name)  # Standalone function
+                # If stop_server completes without error, it means stop was successful or handled.
                 logger.info(f"Stop initiated successfully for server '{server_name}'.")
-                return True  # Server was running, stop attempt made (successful or not)
+                return True
+            except ServerNotFoundError:
+                # This case might occur if the process is running but the executable
+                # was removed before stop_server (which calls _get_server_details) is called.
+                logger.warning(
+                    f"Server process '{server_name}' seems to be running, but its executable was not found by stop_server. Manual check might be needed."
+                )
+                # Treat as if it was running but couldn't be stopped cleanly by this method.
+                raise ServerStopError(
+                    f"Server '{server_name}' process found, but executable missing. Stop via stop_server failed."
+                )
             except (ServerStopError, SendCommandError, CommandNotFoundError) as e:
                 logger.error(
-                    f"Attempt to stop server '{server_name}' failed: {e}", exc_info=True
+                    f"Attempt to stop server '{server_name}' via stop_server failed: {e}",
+                    exc_info=True,
                 )
-                # Even though stop failed, it *was* running. Raise the error.
-                raise
-            except ServerNotFoundError:
-                logger.warning(
-                    f"Server process '{server_name}' seems to be running, but executable not found. Cannot use class stop method."
-                )
-                # Report that it was running but couldn't be stopped cleanly.
-                raise ServerStopError(
-                    f"Server '{server_name}' running but executable missing. Stop failed."
-                )
-
+                raise  # Re-raise the specific error from stop_server
         else:
-            logger.debug(f"Server '{server_name}' is not currently running.")
-            return False  # Server was not running
+            logger.debug(
+                f"Server '{server_name}' is not currently running (checked via system_base)."
+            )
+            return False
 
-    except Exception as e:  # Catch unexpected errors during the check/stop process
+    except Exception as e:  # Catch other unexpected errors
         logger.error(
             f"Unexpected error during stop_server_if_running for '{server_name}': {e}",
             exc_info=True,
         )
+        # Wrap in ServerStopError for consistent error type from this function on failure
         raise ServerStopError(
-            f"Unexpected error stopping server '{server_name}': {e}"
+            f"Unexpected error attempting to stop server '{server_name}': {e}"
         ) from e

--- a/src/bedrock_server_manager/core/server/world.py
+++ b/src/bedrock_server_manager/core/server/world.py
@@ -233,7 +233,7 @@ def export_world(world_dir_path: str, target_mcworld_path: str) -> None:
         raise BackupWorldError(f"Unexpected error exporting world: {e}") from e
 
 
-def import_world(server_name: str, mcworld_backup_path: str, base_dir: str) -> None:
+def import_world(server_name: str, mcworld_backup_path: str, base_dir: str) -> str:
     """
     Imports (restores) a world from a .mcworld backup file into a server's world directory.
 
@@ -320,3 +320,5 @@ def import_world(server_name: str, mcworld_backup_path: str, base_dir: str) -> N
         raise RestoreError(
             f"Unexpected error during world import for '{server_name}': {e}"
         ) from e
+
+    return world_name

--- a/src/bedrock_server_manager/core/system/linux.py
+++ b/src/bedrock_server_manager/core/system/linux.py
@@ -154,10 +154,10 @@ WorkingDirectory={server_dir}
 # Environment="LD_LIBRARY_PATH=."
 {autoupdate_line}
 # Use absolute path to EXPATH
-ExecStart={EXPATH} systemd-start --server "{server_name}"
+ExecStart={EXPATH} start-server --server "{server_name}" --mode direct
 ExecStop={EXPATH} systemd-stop --server "{server_name}"
 # ExecReload might not be necessary if stop/start works reliably
-# ExecReload={EXPATH} systemd-stop --server "{server_name}" && {EXPATH} systemd-start --server "{server_name}"
+# ExecReload={EXPATH} systemd-stop --server "{server_name}" && {EXPATH} start-server --server "{server_name}" -mode direct
 # Restart behavior
 Restart=on-failure
 RestartSec=10s

--- a/src/bedrock_server_manager/core/system/linux.py
+++ b/src/bedrock_server_manager/core/system/linux.py
@@ -375,7 +375,7 @@ def _disable_systemd_service(server_name: str) -> None:
         raise ServiceError(error_msg) from e
 
 
-def _systemd_start_server(server_name: str, server_dir: str) -> None:
+def _linux_start_server(server_name: str, server_dir: str) -> None:
     """
     Starts the Bedrock server process within a detached 'screen' session.
 
@@ -480,7 +480,7 @@ def _systemd_start_server(server_name: str, server_dir: str) -> None:
         raise CommandNotFoundError(e.filename) from e
 
 
-def _systemd_stop_server(server_name: str, server_dir: str) -> None:
+def _linux_stop_server(server_name: str, server_dir: str) -> None:
     """
     Stops the Bedrock server running within a 'screen' session.
 

--- a/src/bedrock_server_manager/web/routes/server_actions_routes.py
+++ b/src/bedrock_server_manager/web/routes/server_actions_routes.py
@@ -67,7 +67,9 @@ def start_server_route(server_name: str) -> Tuple[Response, int]:
     try:
         # Call the start server API function
         # base_dir resolution handled within the api function
-        result = server_api.start_server(server_name)  # Returns dict
+        result = server_api.start_server(
+            server_name=server_name, mode="detached"
+        )  # Returns dict
         logger.debug(f"API Start Server '{server_name}': Handler response: {result}")
 
         # Determine HTTP status based on the handler's response

--- a/src/bedrock_server_manager/web/routes/server_actions_routes.py
+++ b/src/bedrock_server_manager/web/routes/server_actions_routes.py
@@ -23,6 +23,7 @@ from bedrock_server_manager.web.utils.auth_decorators import (
 )
 from bedrock_server_manager.api import server as server_api
 from bedrock_server_manager.api import server_install_config
+from bedrock_server_manager.core.server.server import manage_server_config
 from bedrock_server_manager.api import system as system_api
 from bedrock_server_manager.error import (
     InvalidServerNameError,
@@ -147,7 +148,10 @@ def stop_server_route(server_name: str) -> Tuple[Response, int]:
 
     try:
         # Call the stop server API function
-        result = server_api.stop_server(server_name)  # Returns dict
+        result = server_api.stop_server(
+            server_name=server_name,
+            mode=manage_server_config(server_name, "start_method", "read"),
+        )  # Returns dict
         logger.debug(f"API Stop Server '{server_name}': Handler response: {result}")
 
         if isinstance(result, dict) and result.get("status") == "success":


### PR DESCRIPTION
- Remove BedrockServer class in core.server.server
- Revamped start/stop
   - Windows start/stop received the bigger revamp, allowing send command support
   - Linux systemd start/stop commands and functions have be removed, moved directly into the base start/stop command
   - Linux users need to reconfigure auto update/service
- Revamped/cleaned up backup/restore modules
- Cleaned up addons api module
- Use central start/stop context manager for operations such as export world, update etc etc
- Cleaned up the install/update functions