### PR TITLE
feat: windows service

### DIFF
--- a/src/bedrock_server_manager/api/system.py
+++ b/src/bedrock_server_manager/api/system.py
@@ -3,11 +3,11 @@
 
 This module orchestrates calls to `BedrockServer` class methods to manage
 system-related configurations and information, such as process resource usage
-and systemd service management on Linux.
+and system service management (systemd on Linux, Windows Services on Windows).
 """
 import logging
 import platform
-from typing import Dict, Optional, Any
+from typing import Dict, Any
 
 # Plugin system imports to bridge API functionality.
 from bedrock_server_manager import plugin_manager
@@ -28,9 +28,7 @@ logger = logging.getLogger(__name__)
 register_api(
     "get_bedrock_process_info", lambda **kwargs: get_bedrock_process_info(**kwargs)
 )
-register_api(
-    "create_systemd_service", lambda **kwargs: create_systemd_service(**kwargs)
-)
+register_api("create_server_service", lambda **kwargs: create_server_service(**kwargs))
 register_api("set_autoupdate", lambda **kwargs: set_autoupdate(**kwargs))
 register_api("enable_server_service", lambda **kwargs: enable_server_service(**kwargs))
 register_api(
@@ -91,20 +89,24 @@ def get_bedrock_process_info(server_name: str) -> Dict[str, Any]:
         }
 
 
-def create_systemd_service(server_name: str, autostart: bool = False) -> Dict[str, str]:
-    """Creates (or updates) a systemd user service for the server (Linux-only).
+def create_server_service(server_name: str, autostart: bool = False) -> Dict[str, str]:
+    """Creates (or updates) a system service for the server.
 
-    This function generates a systemd service file, allowing the server to be
-    managed by `systemctl`. It can also enable the service to start on boot.
+    On Linux, this creates a systemd user service.
+    On Windows, this creates a Windows Service (requires Administrator privileges).
+
+    This function generates a service file, allowing the server to be
+    managed by the host OS's service manager. It can also enable the
+    service to start on boot/login.
 
     Args:
         server_name: The name of the server.
-        autostart: If True, the service will be enabled to start on system boot.
+        autostart: If True, the service will be enabled to start on system boot/login.
             If False, it will be disabled. Defaults to False.
 
     Returns:
         A dictionary with the operation status and a message. Returns an error
-        on non-Linux systems.
+        on unsupported systems.
 
     Raises:
         InvalidServerNameError: If `server_name` is not provided.
@@ -119,41 +121,41 @@ def create_systemd_service(server_name: str, autostart: bool = False) -> Dict[st
     result = {}
     try:
         server = BedrockServer(server_name)
-        server.create_systemd_service_file()
+        # These methods are implemented on BedrockServer, which delegates to
+        # the appropriate OS-specific mixin.
+        server.create_service()
 
         # Enable or disable the service for autostart based on the flag.
         if autostart:
-            server.enable_systemd_service()
+            server.enable_service()
             action = "created and enabled"
         else:
-            server.disable_systemd_service()
+            server.disable_service()
             action = "created and disabled"
 
         result = {
             "status": "success",
-            "message": f"Systemd service {action} successfully.",
+            "message": f"System service {action} successfully.",
         }
 
-    except NotImplementedError as e:
-        # This error is raised by core methods on non-Linux systems.
-        result = {"status": "error", "message": str(e)}
     except BSMError as e:
+        # This will catch SystemError, PermissionsError, etc. from the mixins.
         logger.error(
-            f"API: Failed to configure systemd service for '{server_name}': {e}",
+            f"API: Failed to configure system service for '{server_name}': {e}",
             exc_info=True,
         )
         result = {
             "status": "error",
-            "message": f"Failed to configure systemd service: {e}",
+            "message": f"Failed to configure system service: {e}",
         }
     except Exception as e:
         logger.error(
-            f"API: Unexpected error creating systemd service for '{server_name}': {e}",
+            f"API: Unexpected error creating system service for '{server_name}': {e}",
             exc_info=True,
         )
         result = {
             "status": "error",
-            "message": f"Unexpected error creating systemd service: {e}",
+            "message": f"Unexpected error creating system service: {e}",
         }
     finally:
         plugin_manager.trigger_event(
@@ -236,7 +238,11 @@ def set_autoupdate(server_name: str, autoupdate_value: str) -> Dict[str, str]:
 
 
 def enable_server_service(server_name: str) -> Dict[str, str]:
-    """Enables the systemd user service for autostart (Linux-only).
+    """Enables the system service for autostart.
+
+    On Linux, this enables the systemd user service.
+    On Windows, this sets the Windows Service start type to 'Automatic'
+    (requires Administrator privileges).
 
     Args:
         server_name: The name of the server whose service will be enabled.
@@ -257,17 +263,15 @@ def enable_server_service(server_name: str) -> Dict[str, str]:
     result = {}
     try:
         server = BedrockServer(server_name)
-        server.enable_systemd_service()
+        server.enable_service()
         result = {
             "status": "success",
             "message": f"Service for '{server_name}' enabled successfully.",
         }
 
-    except NotImplementedError as e:
-        result = {"status": "error", "message": str(e)}
     except BSMError as e:
         logger.error(
-            f"API: Failed to enable systemd service for '{server_name}': {e}",
+            f"API: Failed to enable system service for '{server_name}': {e}",
             exc_info=True,
         )
         result = {"status": "error", "message": f"Failed to enable service: {e}"}
@@ -292,7 +296,11 @@ def enable_server_service(server_name: str) -> Dict[str, str]:
 
 
 def disable_server_service(server_name: str) -> Dict[str, str]:
-    """Disables the systemd user service from autostarting (Linux-only).
+    """Disables the system service from autostarting.
+
+    On Linux, this disables the systemd user service.
+    On Windows, this sets the Windows Service start type to 'Disabled'
+    (requires Administrator privileges).
 
     Args:
         server_name: The name of the server whose service will be disabled.
@@ -313,17 +321,15 @@ def disable_server_service(server_name: str) -> Dict[str, str]:
     result = {}
     try:
         server = BedrockServer(server_name)
-        server.disable_systemd_service()
+        server.disable_service()
         result = {
             "status": "success",
             "message": f"Service for '{server_name}' disabled successfully.",
         }
 
-    except NotImplementedError as e:
-        result = {"status": "error", "message": str(e)}
     except BSMError as e:
         logger.error(
-            f"API: Failed to disable systemd service for '{server_name}': {e}",
+            f"API: Failed to disable system service for '{server_name}': {e}",
             exc_info=True,
         )
         result = {"status": "error", "message": f"Failed to disable service: {e}"}

--- a/src/bedrock_server_manager/cli/server_actions.py
+++ b/src/bedrock_server_manager/cli/server_actions.py
@@ -8,6 +8,8 @@ updating, and sending commands.
 """
 
 import logging
+import platform
+import sys
 from typing import Tuple
 
 import click
@@ -26,6 +28,16 @@ from bedrock_server_manager.cli.utils import (
     ServerNameValidator,
 )
 from bedrock_server_manager.error import BSMError
+if platform.system() == "Windows":
+    try:
+        from bedrock_server_manager.core.system.windows import BedrockServerWindowsService, PYWIN32_AVAILABLE
+        if PYWIN32_AVAILABLE:
+            import win32serviceutil
+    except ImportError:
+        PYWIN32_AVAILABLE = False
+else:
+    PYWIN32_AVAILABLE = False
+
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +55,7 @@ def server():
 @click.option(
     "-m",
     "--mode",
-    type=click.Choice(["direct", "detached"], case_sensitive=False),
+    type=click.Choice(["direct", "detached", "service"], case_sensitive=False),
     default="detached",
     show_default=True,
     help="Start mode: 'detached' runs in background, 'direct' blocks terminal.",
@@ -51,6 +63,27 @@ def server():
 def start_server(server_name: str, mode: str):
     """Starts a specific Bedrock server instance."""
     click.echo(f"Attempting to start server '{server_name}' in {mode} mode...")
+
+    if mode == "service":
+        if platform.system() == "Windows" and PYWIN32_AVAILABLE:
+            # We need to map our generic service class to the specific service
+            # name that the SCM is trying to run.
+            service_name_internal = f"bds-{server_name}"
+            
+            # This tells the framework: "When you receive a command for a service
+            # named 'bds-test_2', you should use the BedrockServerWindowsService class."
+            # This is the robust, intended way to use the library.
+            # We no longer need to touch sys.argv at all.
+            class ServiceHandler(BedrockServerWindowsService):
+                 _svc_name_ = service_name_internal
+                 _svc_display_name_ = f"Bedrock Server ({server_name})"
+
+            win32serviceutil.HandleCommandLine(ServiceHandler)
+            return
+        else:
+            logger.error("'service' mode is for internal use by the Windows SCM only.")
+            sys.exit(1)
+
     try:
         response = server_api.start_server(server_name, mode)
         # Custom response handling because 'direct' mode blocks and won't show this.

--- a/src/bedrock_server_manager/cli/system.py
+++ b/src/bedrock_server_manager/cli/system.py
@@ -23,8 +23,12 @@ from bedrock_server_manager.cli.utils import handle_api_response as _handle_api_
 from bedrock_server_manager.core.manager import BedrockServerManager
 from bedrock_server_manager.error import BSMError
 
-if platform.system() == "Windows":  
-    from bedrock_server_manager.core.system.windows_class import BedrockServerWindowsService, PYWIN32_AVAILABLE
+if platform.system() == "Windows":
+    from bedrock_server_manager.core.system.windows_class import (
+        BedrockServerWindowsService,
+        PYWIN32_AVAILABLE,
+    )
+
     if PYWIN32_AVAILABLE:
         import win32serviceutil
         import servicemanager
@@ -353,13 +357,14 @@ def monitor_usage(server_name: str):
     except (KeyboardInterrupt, click.Abort):
         click.secho("\nMonitoring stopped.", fg="green")
 
+
 @system.command(
     "_run-service",
     hidden=True,
     context_settings=dict(
         ignore_unknown_options=True,
         allow_extra_args=True,
-    )
+    ),
 )
 @click.option("-s", "--server", "server_name", required=True)
 @click.pass_context
@@ -368,11 +373,12 @@ def _run_service(ctx, server_name: str):
     (Internal use only) Entry point for the Windows Service Manager.
     """
     if platform.system() == "Windows" and PYWIN32_AVAILABLE:
+
         class ServiceHandler(BedrockServerWindowsService):
             _svc_name_ = f"bds-{server_name}"
             _svc_display_name_ = f"Bedrock Server ({server_name})"
 
-        if 'debug' in ctx.args:
+        if "debug" in ctx.args:
             # Debug mode runs the service logic in the console and blocks.
             logger.info(f"Starting service '{server_name}' in DEBUG mode.")
             win32serviceutil.DebugService(ServiceHandler, argv=[f"bds-{server_name}"])

--- a/src/bedrock_server_manager/core/bedrock_server.py
+++ b/src/bedrock_server_manager/core/bedrock_server.py
@@ -26,6 +26,9 @@ from bedrock_server_manager.core.server.addon_mixin import ServerAddonMixin
 from bedrock_server_manager.core.server.backup_restore_mixin import ServerBackupMixin
 from bedrock_server_manager.core.server.systemd_mixin import ServerSystemdMixin
 from bedrock_server_manager.core.server.player_mixin import ServerPlayerMixin
+from bedrock_server_manager.core.server.windows_service_mixin import (
+    ServerWindowsServiceMixin,
+)
 from bedrock_server_manager.core.server.config_management_mixin import (
     ServerConfigManagementMixin,
 )
@@ -46,6 +49,7 @@ class BedrockServer(
     ServerAddonMixin,
     ServerBackupMixin,
     ServerSystemdMixin,
+    ServerWindowsServiceMixin,
     ServerPlayerMixin,
     ServerConfigManagementMixin,
     ServerInstallUpdateMixin,
@@ -129,6 +133,74 @@ class BedrockServer(
             f"<BedrockServer(name='{self.server_name}', os='{self.os_type}', "
             f"dir='{self.server_dir}', manager_expath='{self.manager_expath}')>"
         )
+
+    def create_service(self):
+        """Creates or updates the system service for this server."""
+        if self.os_type == "Linux":
+            return self.create_systemd_service_file()
+        elif self.os_type == "Windows":
+            return self.create_windows_service()
+        else:
+            raise NotImplementedError(
+                f"Service management is not supported on {self.os_type}."
+            )
+
+    def enable_service(self):
+        """Enables the system service to start on boot/login."""
+        if self.os_type == "Linux":
+            return self.enable_systemd_service()
+        elif self.os_type == "Windows":
+            return self.enable_windows_service()
+        else:
+            raise NotImplementedError(
+                f"Service management is not supported on {self.os_type}."
+            )
+
+    def disable_service(self):
+        """Disables the system service from starting on boot/login."""
+        if self.os_type == "Linux":
+            return self.disable_systemd_service()
+        elif self.os_type == "Windows":
+            return self.disable_windows_service()
+        else:
+            raise NotImplementedError(
+                f"Service management is not supported on {self.os_type}."
+            )
+
+    def remove_service(self):
+        """Removes/deletes the system service for this server."""
+        if self.os_type == "Linux":
+            return self.remove_systemd_service_file()
+        elif self.os_type == "Windows":
+            return self.remove_windows_service()
+        else:
+            raise NotImplementedError(
+                f"Service management is not supported on {self.os_type}."
+            )
+
+    def check_service_exists(self) -> bool:
+        """Checks if a system service has been created for this server."""
+        if self.os_type == "Linux":
+            return self.check_systemd_service_file_exists()
+        elif self.os_type == "Windows":
+            return self.check_windows_service_exists()
+        return False
+
+    def is_service_active(self) -> bool:
+        """Checks if the system service for this server is currently active/running."""
+        if self.os_type == "Linux":
+            return self.is_systemd_service_active()
+        elif self.os_type == "Windows":
+            return self.is_windows_service_active()
+        return False
+
+    def is_service_enabled(self) -> bool:
+        """Checks if the system service for this server is enabled to start on boot/login."""
+        if self.os_type == "Linux":
+            return self.is_systemd_service_enabled()
+        elif self.os_type == "Windows":
+            return self.is_windows_service_enabled()
+        return False
 
     def get_summary_info(self) -> Dict[str, Any]:
         """Returns a dictionary with a comprehensive summary of the server's state.

--- a/src/bedrock_server_manager/core/server/windows_service_mixin.py
+++ b/src/bedrock_server_manager/core/server/windows_service_mixin.py
@@ -11,7 +11,6 @@ Administrator privileges.
 """
 import os
 import subprocess
-import logging
 
 # Local application imports.
 from bedrock_server_manager.core.server.base_server_mixin import BedrockServerBaseMixin
@@ -101,8 +100,20 @@ class ServerWindowsServiceMixin(BedrockServerBaseMixin):
         description = (
             f"Manages the Minecraft Bedrock Server instance named '{self.server_name}'."
         )
-        command = f'"{self.manager_expath}" server start --server "{self.server_name}" --mode service'
+        quoted_expath = f'{self.manager_expath}'
+        
+        # 2. Quote the server name.
+        quoted_server_name = f'"{self.server_name}"'
 
+        # 3. Build the full command by joining the parts.
+        command_parts = [
+            quoted_expath,
+            "system",
+            "_run-service",
+            "--server",
+            quoted_server_name
+        ]
+        command = " ".join(command_parts)
         self.logger.info(
             f"Creating/updating Windows service '{self.windows_service_name}' for server '{self.server_name}'."
         )

--- a/src/bedrock_server_manager/core/server/windows_service_mixin.py
+++ b/src/bedrock_server_manager/core/server/windows_service_mixin.py
@@ -100,8 +100,8 @@ class ServerWindowsServiceMixin(BedrockServerBaseMixin):
         description = (
             f"Manages the Minecraft Bedrock Server instance named '{self.server_name}'."
         )
-        quoted_expath = f'{self.manager_expath}'
-        
+        quoted_expath = f"{self.manager_expath}"
+
         # 2. Quote the server name.
         quoted_server_name = f'"{self.server_name}"'
 
@@ -111,7 +111,7 @@ class ServerWindowsServiceMixin(BedrockServerBaseMixin):
             "system",
             "_run-service",
             "--server",
-            quoted_server_name
+            quoted_server_name,
         ]
         command = " ".join(command_parts)
         self.logger.info(

--- a/src/bedrock_server_manager/core/server/windows_service_mixin.py
+++ b/src/bedrock_server_manager/core/server/windows_service_mixin.py
@@ -1,0 +1,243 @@
+# bedrock_server_manager/core/server/windows_service_mixin.py
+"""Provides the ServerWindowsServiceMixin for the BedrockServer class.
+
+This mixin encapsulates all Windows-specific Service management for a
+server instance. It allows for the creation, enabling, disabling, removal, and
+status checking of Windows Services that manage the Bedrock server process,
+facilitating background operation and autostart capabilities.
+
+NOTE: All operations in this mixin require the application to be run with
+Administrator privileges.
+"""
+import os
+import subprocess
+import logging
+
+# Local application imports.
+from bedrock_server_manager.core.server.base_server_mixin import BedrockServerBaseMixin
+from bedrock_server_manager.core.system import windows as system_windows_utils
+from bedrock_server_manager.error import (
+    SystemError,
+    PermissionsError,
+    MissingArgumentError,
+    AppFileNotFoundError,
+)
+
+
+class ServerWindowsServiceMixin(BedrockServerBaseMixin):
+    """A mixin for BedrockServer to manage a Windows Service (Windows-only).
+
+    This class provides methods to create, enable, disable, remove, and check
+    the status of a Windows Service associated with the server instance.
+
+    All methods require Administrator privileges.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initializes the ServerWindowsServiceMixin.
+
+        This constructor calls `super().__init__` to ensure proper method
+        resolution order in the context of multiple inheritance. It relies on
+        attributes (like `server_name`, `server_dir`, `manager_expath`, `os_type`)
+        from the base class.
+        """
+        super().__init__(*args, **kwargs)
+        # self.server_name, self.base_dir, self.manager_expath, self.logger, and self.os_type are available from BaseMixin.
+
+    def _ensure_windows_for_service(self, operation_name: str):
+        """A helper to verify the OS is Windows before a service operation.
+
+        Args:
+            operation_name: The name of the operation being attempted, for logging.
+
+        Raises:
+            SystemError: If the operating system is not Windows.
+        """
+        if self.os_type != "Windows":
+            msg = f"Windows Service operation '{operation_name}' is only supported on Windows. Server OS: {self.os_type}"
+            self.logger.warning(msg)
+            raise SystemError(msg)
+
+    @property
+    def windows_service_name(self) -> str:
+        """Returns the internal service name (e.g., 'bds-MyServer')."""
+        return f"bds-{self.server_name}"
+
+    @property
+    def windows_service_display_name(self) -> str:
+        """Returns the user-friendly display name for the service."""
+        return f"Bedrock Server ({self.server_name})"
+
+    def check_windows_service_exists(self) -> bool:
+        """Checks if the Windows Service for this server exists.
+
+        Returns:
+            True if the service exists, False otherwise.
+        """
+        self._ensure_windows_for_service("check_windows_service_exists")
+        # Delegate the check to the generic system utility.
+        return system_windows_utils.check_service_exists(self.windows_service_name)
+
+    def create_windows_service(self):
+        """Creates or updates the Windows Service for this server.
+
+        Requires Administrator privileges.
+
+        Raises:
+            SystemError: If the OS is not Windows.
+            AppFileNotFoundError: If the main application executable path is not found.
+            PermissionsError: If not run with Administrator privileges.
+        """
+        self._ensure_windows_for_service("create_windows_service")
+
+        if not self.manager_expath or not os.path.isfile(self.manager_expath):
+            raise AppFileNotFoundError(
+                str(self.manager_expath),
+                f"Manager executable for '{self.server_name}' service",
+            )
+
+        # Define the properties for the Windows Service.
+        # The command must have quoted paths to handle spaces.
+        description = (
+            f"Manages the Minecraft Bedrock Server instance named '{self.server_name}'."
+        )
+        command = f'"{self.manager_expath}" server start --server "{self.server_name}" --mode service'
+
+        self.logger.info(
+            f"Creating/updating Windows service '{self.windows_service_name}' for server '{self.server_name}'."
+        )
+        try:
+            # Delegate the service creation to the generic system utility.
+            system_windows_utils.create_windows_service(
+                service_name=self.windows_service_name,
+                display_name=self.windows_service_display_name,
+                description=description,
+                command=command,
+            )
+            self.logger.info(
+                f"Windows service '{self.windows_service_name}' created/updated successfully."
+            )
+        except (MissingArgumentError, SystemError, PermissionsError) as e:
+            self.logger.error(
+                f"Failed to create/update Windows service '{self.windows_service_name}': {e}"
+            )
+            raise
+
+    def enable_windows_service(self):
+        """Enables the Windows Service (sets start type to Automatic).
+
+        Requires Administrator privileges.
+
+        Raises:
+            SystemError: If not on Windows or if the operation fails.
+            PermissionsError: If not run with Administrator privileges.
+        """
+        self._ensure_windows_for_service("enable_windows_service")
+        self.logger.info(f"Enabling Windows service '{self.windows_service_name}'.")
+        try:
+            system_windows_utils.enable_windows_service(self.windows_service_name)
+            self.logger.info(
+                f"Windows service '{self.windows_service_name}' enabled successfully."
+            )
+        except (SystemError, PermissionsError, MissingArgumentError) as e:
+            self.logger.error(
+                f"Failed to enable Windows service '{self.windows_service_name}': {e}"
+            )
+            raise
+
+    def disable_windows_service(self):
+        """Disables the Windows Service (sets start type to Disabled).
+
+        Requires Administrator privileges.
+
+        Raises:
+            SystemError: If not on Windows or if the operation fails.
+            PermissionsError: If not run with Administrator privileges.
+        """
+        self._ensure_windows_for_service("disable_windows_service")
+        self.logger.info(f"Disabling Windows service '{self.windows_service_name}'.")
+        try:
+            system_windows_utils.disable_windows_service(self.windows_service_name)
+            self.logger.info(
+                f"Windows service '{self.windows_service_name}' disabled successfully."
+            )
+        except (SystemError, PermissionsError, MissingArgumentError) as e:
+            self.logger.error(
+                f"Failed to disable Windows service '{self.windows_service_name}': {e}"
+            )
+            raise
+
+    def remove_windows_service(self):
+        """Removes (deletes) the Windows Service for this server.
+
+        Requires Administrator privileges. The service should be stopped first.
+
+        Raises:
+            SystemError: If not on Windows or if the operation fails.
+            PermissionsError: If not run with Administrator privileges.
+        """
+        self._ensure_windows_for_service("remove_windows_service")
+        self.logger.info(f"Removing Windows service '{self.windows_service_name}'.")
+        try:
+            system_windows_utils.delete_windows_service(self.windows_service_name)
+            self.logger.info(
+                f"Windows service '{self.windows_service_name}' removed successfully."
+            )
+        except (SystemError, PermissionsError, MissingArgumentError) as e:
+            self.logger.error(
+                f"Failed to remove Windows service '{self.windows_service_name}': {e}"
+            )
+            raise
+
+    def is_windows_service_active(self) -> bool:
+        """Checks if the Windows Service for this server is currently running.
+
+        Uses the built-in `sc.exe` command-line tool.
+
+        Returns:
+            True if the service is in the 'RUNNING' state, False otherwise.
+        """
+        self._ensure_windows_for_service("is_windows_service_active")
+        try:
+            # Use 'sc query' to check the state of the service.
+            result = subprocess.check_output(
+                ["sc", "query", self.windows_service_name],
+                text=True,
+                stderr=subprocess.DEVNULL,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            # A running service will have a line like "        STATE              : 4  RUNNING"
+            return "STATE" in result and "RUNNING" in result
+        except subprocess.CalledProcessError:
+            # This error occurs if the service does not exist.
+            return False
+        except FileNotFoundError:
+            # sc.exe not found, which is highly unlikely on Windows.
+            self.logger.warning("`sc.exe` command not found.")
+            return False
+
+    def is_windows_service_enabled(self) -> bool:
+        """Checks if the Windows Service is enabled (set to start automatically).
+
+        Uses the built-in `sc.exe` command-line tool.
+
+        Returns:
+            True if the service start type is 'AUTO_START', False otherwise.
+        """
+        self._ensure_windows_for_service("is_windows_service_enabled")
+        try:
+            # Use 'sc qc' (query config) to check the start type.
+            result = subprocess.check_output(
+                ["sc", "qc", self.windows_service_name],
+                text=True,
+                stderr=subprocess.DEVNULL,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            # An enabled service will have a line like "        START_TYPE         : 2   AUTO_START"
+            return "START_TYPE" in result and "AUTO_START" in result
+        except subprocess.CalledProcessError:
+            # This error occurs if the service does not exist.
+            return False
+        except FileNotFoundError:
+            self.logger.warning("`sc.exe` command not found.")
+            return False

--- a/src/bedrock_server_manager/core/system/windows.py
+++ b/src/bedrock_server_manager/core/system/windows.py
@@ -68,7 +68,6 @@ managed_bedrock_servers: Dict[str, Dict[str, Any]] = {}
 # A module-level event to signal a shutdown for servers running in the foreground.
 _foreground_server_shutdown_event = threading.Event()
 
-        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
 # NOTE: All functions in this section require Administrator privileges to interact
 # with the Windows Service Control Manager (SCM).
 

--- a/src/bedrock_server_manager/core/system/windows.py
+++ b/src/bedrock_server_manager/core/system/windows.py
@@ -8,8 +8,11 @@ This module includes functions for:
 - Handling OS signals for graceful shutdown of the foreground server.
 - Sending commands to the server via the named pipe.
 - Stopping the server process by PID.
+- Creating, managing, and deleting Windows Services to run the server in the
+  background, which requires Administrator privileges.
 
-It relies on the optional `pywin32` package for named pipe functionality.
+It relies on the pywin32 package for named pipe and service
+functionality.
 """
 import os
 import threading
@@ -24,6 +27,8 @@ from typing import Optional, List, Dict, Any
 try:
     import win32pipe
     import win32file
+    import win32service
+    import win32serviceutil
     import pywintypes
 
     PYWIN32_AVAILABLE = True
@@ -31,6 +36,8 @@ except ImportError:
     PYWIN32_AVAILABLE = False
     win32pipe = None
     win32file = None
+    win32service = None
+    win32serviceutil = None
     pywintypes = None
 
 # Local application imports.
@@ -45,6 +52,7 @@ from bedrock_server_manager.error import (
     SystemError,
     SendCommandError,
     ServerNotRunningError,
+    PermissionsError,
 )
 
 logger = logging.getLogger(__name__)
@@ -59,6 +67,424 @@ managed_bedrock_servers: Dict[str, Dict[str, Any]] = {}
 
 # A module-level event to signal a shutdown for servers running in the foreground.
 _foreground_server_shutdown_event = threading.Event()
+
+
+# --- WINDOWS SERVICE IMPLEMENTATION ---
+class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
+    """A pywin32 ServiceFramework class to properly manage the server as a service."""
+    _svc_name_ = "BedrockServerWindowsService_Base"
+    _svc_display_name_ = "Bedrock Server Manager Service"
+    _svc_description_ = "Manages a Minecraft Bedrock Server instance."
+
+    def __init__(self, args):
+        win32serviceutil.ServiceFramework.__init__(self, args)
+        self._svc_name_ = args[0]
+        # Extract the server name (e.g., 'test') from the service name 'bds-test'
+        self.server_name = self._svc_name_.replace("bds-", "", 1)
+        self.server = BedrockServer(self.server_name)
+        self._svc_display_name_ = self.server.windows_service_display_name
+        self.shutdown_event = threading.Event()
+        self.bedrock_process: Optional[subprocess.Popen] = None
+        self.pipe_listener_thread: Optional[threading.Thread] = None
+
+    def SvcStop(self):
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        logger.info(f"Service '{self._svc_name_}': Stop request received.")
+        self.shutdown_event.set()
+        try:
+            pipe_path = PIPE_NAME_TEMPLATE.format(server_name=re.sub(r"\W+", "_", self.server.server_name))
+            with open(pipe_path, "w") as f:
+                pass
+        except Exception:
+            pass
+
+    def SvcDoRun(self):
+        logger.info(f"Service '{self._svc_name_}': SvcDoRun started.")
+        self.ReportServiceStatus(win32service.SERVICE_START_PENDING)
+
+        try:
+            server_exe_path = self.server.bedrock_executable_path
+            pipe_name = PIPE_NAME_TEMPLATE.format(server_name=re.sub(r"\W+", "_", self.server.server_name))
+            output_file = self.server.server_log_path
+            
+            with open(output_file, 'ab') as f:
+                self.bedrock_process = subprocess.Popen(
+                    [server_exe_path],
+                    cwd=self.server.server_dir,
+                    stdin=subprocess.PIPE,
+                    stdout=f,
+                    stderr=subprocess.STDOUT,
+                    text=False, bufsize=0,
+                    creationflags=subprocess.CREATE_NO_WINDOW
+                )
+
+            logger.info(f"Service '{self._svc_name_}': Started Bedrock process PID {self.bedrock_process.pid}.")
+            pid_file_path = self.server.get_pid_file_path()
+            core_process.write_pid_to_file(pid_file_path, self.bedrock_process.pid)
+
+            self.pipe_listener_thread = threading.Thread(
+                target=_main_pipe_server_listener_thread,
+                args=(pipe_name, self.bedrock_process, self.server_name, self.shutdown_event),
+                daemon=True
+            )
+            self.pipe_listener_thread.start()
+
+            self.ReportServiceStatus(win32service.SERVICE_RUNNING)
+            logger.info(f"Service '{self._svc_name_}': Status reported as RUNNING.")
+            self.shutdown_event.wait()
+            logger.info(f"Service '{self._svc_name_}': Shutdown triggered.")
+        
+        except Exception as e:
+            logger.error(f"Service '{self._svc_name_}': Critical error in SvcDoRun: {e}", exc_info=True)
+        
+        finally:
+            if self.bedrock_process and self.bedrock_process.poll() is None:
+                logger.info(f"Service '{self._svc_name_}': Sending 'stop' command.")
+                try:
+                    if self.bedrock_process.stdin and not self.bedrock_process.stdin.closed:
+                        self.bedrock_process.stdin.write(b"stop\r\n")
+                        self.bedrock_process.stdin.flush()
+                        self.bedrock_process.stdin.close()
+                    self.bedrock_process.wait(timeout=settings.get("SERVER_STOP_TIMEOUT_SEC", 30))
+                except (subprocess.TimeoutExpired, OSError, ValueError):
+                    logger.warning(f"Service '{self._svc_name_}': Graceful stop failed, terminating.")
+                    core_process.terminate_process_by_pid(self.bedrock_process.pid)
+
+            if self.pipe_listener_thread and self.pipe_listener_thread.is_alive():
+                self.pipe_listener_thread.join(timeout=3.0)
+
+            core_process.remove_pid_file_if_exists(self.server.get_pid_file_path())
+            logger.info(f"Service '{self._svc_name_}': Cleanup complete.")
+            self.ReportServiceStatus(win32service.SERVICE_STOPPED)
+# NOTE: All functions in this section require Administrator privileges to interact
+# with the Windows Service Control Manager (SCM).
+
+
+def check_service_exists(service_name: str) -> bool:
+    """Checks if a Windows service with the given name exists.
+
+    Args:
+        service_name: The short name of the service to check.
+
+    Returns:
+        True if the service exists, False otherwise. Returns False if pywin32
+        is not installed.
+
+    Raises:
+        MissingArgumentError: If `service_name` is empty.
+        SystemError: For unexpected SCM errors.
+    """
+    if not PYWIN32_AVAILABLE:
+        return False
+    if not service_name:
+        raise MissingArgumentError("Service name cannot be empty.")
+
+    scm_handle = None
+    service_handle = None
+    try:
+        scm_handle = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_CONNECT
+        )
+        service_handle = win32service.OpenService(
+            scm_handle, service_name, win32service.SERVICE_QUERY_STATUS
+        )
+        # If OpenService succeeds, the service exists.
+        return True
+    except pywintypes.error as e:
+        # Error 1060: The specified service does not exist.
+        if e.winerror == 1060:
+            return False
+        # Error 5: Access is denied.
+        elif e.winerror == 5:
+            logger.warning(
+                "Access denied when checking for service '%s'. This check requires Administrator privileges.",
+                service_name,
+            )
+            return False
+        else:
+            raise SystemError(
+                f"Failed to check service '{service_name}': {e.strerror}"
+            ) from e
+    finally:
+        if service_handle:
+            win32service.CloseServiceHandle(service_handle)
+        if scm_handle:
+            win32service.CloseServiceHandle(scm_handle)
+
+
+def create_windows_service(
+    service_name: str,
+    display_name: str,
+    description: str,
+    command: str,
+) -> None:
+    """Creates or updates a Windows service.
+
+    Requires Administrator privileges.
+    """
+    if not PYWIN32_AVAILABLE:
+        raise SystemError("pywin32 is required to manage Windows services.")
+    if not all([service_name, display_name, description, command]):
+        raise MissingArgumentError(
+            "service_name, display_name, description, and command are required."
+        )
+
+    logger.info(f"Attempting to create/update Windows service '{service_name}'...")
+
+    scm_handle = None
+    service_handle = None
+    try:
+        scm_handle = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_ALL_ACCESS
+        )
+
+        service_exists = check_service_exists(service_name)
+
+        if not service_exists:
+            logger.info(f"Service '{service_name}' does not exist. Creating...")
+            # When creating, we can rely on defaults for the service account (LocalSystem)
+            service_handle = win32service.CreateService(
+                scm_handle,
+                service_name,
+                display_name,
+                win32service.SERVICE_ALL_ACCESS,
+                win32service.SERVICE_WIN32_OWN_PROCESS,
+                win32service.SERVICE_AUTO_START,
+                win32service.SERVICE_ERROR_NORMAL,
+                command,
+                None, 0, None, None, None,
+            )
+            logger.info(f"Service '{service_name}' created successfully.")
+        else:
+            logger.info(f"Service '{service_name}' already exists. Updating...")
+            service_handle = win32service.OpenService(
+                scm_handle, service_name, win32service.SERVICE_ALL_ACCESS
+            )
+
+            # --- THIS IS THE CORRECTED PART ---
+            # When updating, we must explicitly tell it to leave the account unchanged
+            # by passing None for the service start name.
+            win32service.ChangeServiceConfig(
+                service_handle,
+                win32service.SERVICE_NO_CHANGE,  # ServiceType
+                win32service.SERVICE_NO_CHANGE,  # StartType
+                win32service.SERVICE_NO_CHANGE,  # ErrorControl
+                command,                        # BinaryPathName
+                None,                           # LoadOrderGroup
+                0,                              # TagId
+                None,                           # Dependencies
+                None,                           # ServiceStartName (THE FIX IS HERE)
+                None,                           # Password
+                display_name,                   # DisplayName
+            )
+            logger.info(f"Service '{service_name}' command and display name updated.")
+
+        # Set or update the service description (this part was already correct)
+        win32service.ChangeServiceConfig2(
+            service_handle, win32service.SERVICE_CONFIG_DESCRIPTION, description
+        )
+        logger.info(f"Service '{service_name}' description updated.")
+
+    except pywintypes.error as e:
+        if e.winerror == 5:
+            raise PermissionsError(
+                f"Failed to create/update service '{service_name}'. This operation requires Administrator privileges."
+            ) from e
+        # Check for error 1057 specifically
+        elif e.winerror == 1057:
+             raise SystemError(f"Failed to update service '{service_name}': {e.strerror}. This can happen if the service account is misconfigured.") from e
+        else:
+            raise SystemError(
+                f"Failed to create/update service '{service_name}': {e.strerror}"
+            ) from e
+    finally:
+        if service_handle:
+            win32service.CloseServiceHandle(service_handle)
+        if scm_handle:
+            win32service.CloseServiceHandle(scm_handle)
+
+
+def enable_windows_service(service_name: str) -> None:
+    """Enables a Windows service by setting its start type to 'Automatic'.
+
+    This function requires Administrator privileges.
+
+    Args:
+        service_name: The name of the service to enable.
+
+    Raises:
+        PermissionsError: If the user lacks Administrator privileges.
+        SystemError: If the service does not exist or another error occurs.
+    """
+    if not PYWIN32_AVAILABLE:
+        raise SystemError("pywin32 is required to manage Windows services.")
+    if not service_name:
+        raise MissingArgumentError("Service name cannot be empty.")
+
+    logger.info(f"Enabling service '{service_name}' (setting to Automatic start)...")
+    scm_handle = None
+    service_handle = None
+    try:
+        scm_handle = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_CONNECT
+        )
+        service_handle = win32service.OpenService(
+            scm_handle, service_name, win32service.SERVICE_CHANGE_CONFIG
+        )
+
+        win32service.ChangeServiceConfig(
+            service_handle,
+            win32service.SERVICE_NO_CHANGE,
+            win32service.SERVICE_AUTO_START,  # Set to Automatic
+            win32service.SERVICE_NO_CHANGE,
+            None,
+            None,
+            0,
+            None,
+            None,
+            None,
+            None,
+        )
+        logger.info(f"Service '{service_name}' enabled successfully.")
+    except pywintypes.error as e:
+        if e.winerror == 5:
+            raise PermissionsError(
+                f"Failed to enable service '{service_name}'. Administrator privileges required."
+            ) from e
+        elif e.winerror == 1060:
+            raise SystemError(
+                f"Cannot enable: Service '{service_name}' not found."
+            ) from e
+        else:
+            raise SystemError(
+                f"Failed to enable service '{service_name}': {e.strerror}"
+            ) from e
+    finally:
+        if service_handle:
+            win32service.CloseServiceHandle(service_handle)
+        if scm_handle:
+            win32service.CloseServiceHandle(scm_handle)
+
+
+def disable_windows_service(service_name: str) -> None:
+    """Disables a Windows service by setting its start type to 'Disabled'.
+
+    This function requires Administrator privileges.
+
+    Args:
+        service_name: The name of the service to disable.
+
+    Raises:
+        PermissionsError: If the user lacks Administrator privileges.
+        SystemError: If the service does not exist or another error occurs.
+    """
+    if not PYWIN32_AVAILABLE:
+        raise SystemError("pywin32 is required to manage Windows services.")
+    if not service_name:
+        raise MissingArgumentError("Service name cannot be empty.")
+
+    logger.info(f"Disabling service '{service_name}'...")
+    scm_handle = None
+    service_handle = None
+    try:
+        scm_handle = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_CONNECT
+        )
+        service_handle = win32service.OpenService(
+            scm_handle, service_name, win32service.SERVICE_CHANGE_CONFIG
+        )
+        win32service.ChangeServiceConfig(
+            service_handle,
+            win32service.SERVICE_NO_CHANGE,
+            win32service.SERVICE_DISABLED,  # Set to Disabled
+            win32service.SERVICE_NO_CHANGE,
+            None,
+            None,
+            0,
+            None,
+            None,
+            None,
+            None,
+        )
+        logger.info(f"Service '{service_name}' disabled successfully.")
+    except pywintypes.error as e:
+        if e.winerror == 5:
+            raise PermissionsError(
+                f"Failed to disable service '{service_name}'. Administrator privileges required."
+            ) from e
+        elif e.winerror == 1060:
+            logger.warning(
+                "Attempted to disable service '%s', but it does not exist.",
+                service_name,
+            )
+            return
+        else:
+            raise SystemError(
+                f"Failed to disable service '{service_name}': {e.strerror}"
+            ) from e
+    finally:
+        if service_handle:
+            win32service.CloseServiceHandle(service_handle)
+        if scm_handle:
+            win32service.CloseServiceHandle(scm_handle)
+
+
+def delete_windows_service(service_name: str) -> None:
+    """Deletes a Windows service.
+
+    This function requires Administrator privileges. The service must be stopped
+    before it can be deleted.
+
+    Args:
+        service_name: The name of the service to delete.
+
+    Raises:
+        PermissionsError: If the user lacks Administrator privileges.
+        SystemError: If the service does not exist or another error occurs.
+    """
+    if not PYWIN32_AVAILABLE:
+        raise SystemError("pywin32 is required to manage Windows services.")
+    if not service_name:
+        raise MissingArgumentError("Service name cannot be empty.")
+
+    logger.info(f"Deleting service '{service_name}'...")
+    scm_handle = None
+    service_handle = None
+    try:
+        scm_handle = win32service.OpenSCManager(
+            None, None, win32service.SC_MANAGER_ALL_ACCESS
+        )
+        service_handle = win32service.OpenService(
+            scm_handle, service_name, win32service.DELETE
+        )
+        win32service.DeleteService(service_handle)
+        logger.info(f"Service '{service_name}' deleted successfully.")
+    except pywintypes.error as e:
+        if e.winerror == 5:
+            raise PermissionsError(
+                f"Failed to delete service '{service_name}'. Administrator privileges required."
+            ) from e
+        elif e.winerror == 1060:
+            logger.warning(
+                "Attempted to delete service '%s', but it does not exist.", service_name
+            )
+            return
+        elif e.winerror == 1072:  # The specified service has been marked for deletion.
+            logger.info(f"Service '{service_name}' was already marked for deletion.")
+            return
+        else:
+            raise SystemError(
+                f"Failed to delete service '{service_name}': {e.strerror}. "
+                "Ensure the service is stopped before deletion."
+            ) from e
+    finally:
+        if service_handle:
+            win32service.CloseServiceHandle(service_handle)
+        if scm_handle:
+            win32service.CloseServiceHandle(scm_handle)
+
+
+# --- FOREGROUND SERVER MANAGEMENT ---
 
 
 def _handle_os_signals(sig, frame):

--- a/src/bedrock_server_manager/core/system/windows_class.py
+++ b/src/bedrock_server_manager/core/system/windows_class.py
@@ -1,0 +1,202 @@
+# bedrock_server_manager/core/system/windows_class.py
+"""Provides Windows-specific implementations for system interactions.
+
+This module includes functions for:
+- Starting the Bedrock server process directly in the foreground.
+- Managing a named pipe server for inter-process communication (IPC) to send
+  commands to the running Bedrock server.
+- Handling OS signals for graceful shutdown of the foreground server.
+- Sending commands to the server via the named pipe.
+- Stopping the server process by PID.
+- Creating, managing, and deleting Windows Services to run the server in the
+  background, which requires Administrator privileges.
+
+It relies on the pywin32 package for named pipe and service
+functionality.
+"""
+import os
+import sys
+import threading
+import time
+import subprocess
+import logging
+import re
+from typing import Optional, Dict, Any
+
+# Third-party imports. pywin32 is optional but required for IPC.
+try:
+    import win32service
+    import win32serviceutil
+
+    PYWIN32_AVAILABLE = True
+except ImportError:
+    PYWIN32_AVAILABLE = False
+    win32pipe = None
+    win32file = None
+    win32service = None
+    win32serviceutil = None
+    pywintypes = None
+
+# Local application imports.
+from bedrock_server_manager.core.system import process as core_process
+from bedrock_server_manager.core.bedrock_server import BedrockServer
+from bedrock_server_manager.core.system.windows import _main_pipe_server_listener_thread
+
+logger = logging.getLogger(__name__)
+
+# --- Constants ---
+BEDROCK_EXECUTABLE_NAME = "bedrock_server.exe"
+PIPE_NAME_TEMPLATE = r"\\.\pipe\BedrockServerPipe_{server_name}"
+
+# A global dictionary to keep track of running server processes and their control objects.
+# This is used to manage the state of servers started in the foreground.
+managed_bedrock_servers: Dict[str, Dict[str, Any]] = {}
+
+# --- WINDOWS SERVICE IMPLEMENTATION ---
+class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
+    """
+    A pywin32 ServiceFramework class to properly manage the server as a service.
+    This version includes robust logging and environment setup to handle
+    the restrictive context in which Windows Services run.
+    """
+    _svc_name_ = "BedrockServerWindowsService_Base"
+    _svc_display_name_ = "Bedrock Server Manager Service"
+    _svc_description_ = "Manages a Minecraft Bedrock Server instance."
+
+    def __init__(self, args):
+        """
+        The service's constructor. This should be as lightweight as possible.
+        Heavy initialization should be deferred to SvcDoRun.
+        """
+        win32serviceutil.ServiceFramework.__init__(self, args)
+        self.shutdown_event = threading.Event()
+        self.bedrock_process: Optional[subprocess.Popen] = None
+        self.logger = None  # Will be initialized in SvcDoRun
+
+        # The first arg from the SCM is always the service name.
+        if args:
+            self._svc_name_ = args[0]
+            self.server_name = self._svc_name_.replace("bds-", "", 1)
+        else:
+            # This case should not happen in a real service start.
+            self.server_name = "unknown_service"
+
+    def emergency_log(self, message: str):
+        """A foolproof logger that writes to a public temp file."""
+        try:
+            # C:\tmp is a common, publicly writable directory.
+            os.makedirs(r"C:\tmp", exist_ok=True)
+            with open(r"C:\tmp\service_debug.log", "a") as f:
+                f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - SVC({self._svc_name_}): {message}\n")
+        except Exception:
+            # If even this fails, there's nothing more we can do.
+            pass
+
+    def SvcStop(self):
+        """Called by the SCM when the service is stopping."""
+        self.emergency_log("Stop request received.")
+        if self.logger:
+            self.logger.info(f"Service '{self._svc_name_}': Stop request received.")
+        self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
+        self.shutdown_event.set()
+
+    def SvcDoRun(self):
+        """The main service entry point, containing all startup and running logic."""
+        # --- Stage 1: Initial Setup (Pre-Logging) ---
+        try:
+            if getattr(sys, 'frozen', False):
+                # If running as a frozen exe (e.g., PyInstaller)
+                script_dir = os.path.dirname(sys.executable)
+            else:
+                # If running as a normal .py script
+                script_dir = os.path.dirname(os.path.realpath(__file__))
+            
+            os.chdir(script_dir)
+            self.emergency_log(f"SvcDoRun started. Working directory set to: {script_dir}")
+        except Exception as e:
+            self.emergency_log(f"CRITICAL FAILURE: Could not set working directory. Error: {e}")
+            self.ReportServiceStatus(win32service.SERVICE_STOPPED)
+            return
+
+        # --- Stage 2: Main Application Logic ---
+        self.ReportServiceStatus(win32service.SERVICE_START_PENDING)
+        try:
+            # Now that the CWD is correct, the main logging system should initialize correctly.
+            self.logger = logging.getLogger(__name__)
+            self.logger.info("Main application logging initialized successfully.")
+
+            self.logger.info("Instantiating BedrockServer object.")
+            self.server = BedrockServer(self.server_name)
+            self._svc_display_name_ = self.server.windows_service_display_name
+            self.logger.info("BedrockServer instantiated successfully.")
+
+            server_exe_path = self.server.bedrock_executable_path
+            pipe_name = PIPE_NAME_TEMPLATE.format(server_name=re.sub(r"\W+", "_", self.server.server_name))
+            output_file = self.server.server_log_path
+            pid_file_path = self.server.get_pid_file_path()
+            self.logger.info(f"Paths prepared. Executable: {server_exe_path}")
+
+            self.logger.info("Attempting to start bedrock_server.exe with Popen.")
+            os.makedirs(self.server.server_dir, exist_ok=True)
+            log_handle = open(output_file, 'ab')
+            self.bedrock_process = subprocess.Popen(
+                [server_exe_path],
+                cwd=self.server.server_dir,
+                stdin=subprocess.PIPE,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                text=False, bufsize=0,
+                creationflags=subprocess.CREATE_NO_WINDOW
+            )
+            self.logger.info(f"bedrock_server.exe started with PID {self.bedrock_process.pid}.")
+
+            self.logger.info("Writing PID file.")
+            core_process.write_pid_to_file(pid_file_path, self.bedrock_process.pid)
+
+            self.logger.info("Starting pipe listener thread.")
+            pipe_listener_thread = threading.Thread(
+                target=_main_pipe_server_listener_thread,
+                args=(pipe_name, self.bedrock_process, self.server_name, self.shutdown_event),
+                daemon=True
+            )
+            pipe_listener_thread.start()
+
+            self.logger.info("--- ALL STARTUP CHECKS PASSED ---")
+            self.logger.info("Reporting SERVICE_RUNNING to SCM.")
+            self.ReportServiceStatus(win32service.SERVICE_RUNNING)
+            self.emergency_log("Service status reported as RUNNING.")
+
+            # Service is now running, wait for a stop signal.
+            self.shutdown_event.wait()
+            self.logger.info("Shutdown event received. Proceeding to cleanup.")
+
+        except Exception as e:
+            self.emergency_log(f"FATAL ERROR in SvcDoRun: {e}")
+            if self.logger:
+                self.logger.error(f"FATAL ERROR in SvcDoRun for service '{self._svc_name_}': {e}", exc_info=True)
+            self.SvcStop()
+
+        finally:
+            # --- Cleanup Logic ---
+            self.emergency_log("Entering cleanup (finally block).")
+            if self.logger:
+                self.logger.info("Entering service cleanup (finally block).")
+
+            if self.bedrock_process and self.bedrock_process.poll() is None:
+                if self.logger: self.logger.info("Sending 'stop' command to Bedrock server.")
+                try:
+                    if self.bedrock_process.stdin and not self.bedrock_process.stdin.closed:
+                        self.bedrock_process.stdin.write(b"stop\r\n")
+                        self.bedrock_process.stdin.flush()
+                        self.bedrock_process.stdin.close()
+                    self.bedrock_process.wait(timeout=20)
+                except Exception as e:
+                    if self.logger: self.logger.warning(f"Graceful stop failed: {e}. Terminating process.")
+                    core_process.terminate_process_by_pid(self.bedrock_process.pid)
+
+            if hasattr(self, 'server'):
+                core_process.remove_pid_file_if_exists(self.server.get_pid_file_path())
+            
+            self.emergency_log("Cleanup complete. Reporting STOPPED.")
+            if self.logger: self.logger.info("Cleanup complete. Reporting STOPPED.")
+            self.ReportServiceStatus(win32service.SERVICE_STOPPED)

--- a/src/bedrock_server_manager/core/system/windows_class.py
+++ b/src/bedrock_server_manager/core/system/windows_class.py
@@ -52,6 +52,7 @@ PIPE_NAME_TEMPLATE = r"\\.\pipe\BedrockServerPipe_{server_name}"
 # This is used to manage the state of servers started in the foreground.
 managed_bedrock_servers: Dict[str, Dict[str, Any]] = {}
 
+
 # --- WINDOWS SERVICE IMPLEMENTATION ---
 class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
     """
@@ -59,6 +60,7 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
     This version includes robust logging and environment setup to handle
     the restrictive context in which Windows Services run.
     """
+
     _svc_name_ = "BedrockServerWindowsService_Base"
     _svc_display_name_ = "Bedrock Server Manager Service"
     _svc_description_ = "Manages a Minecraft Bedrock Server instance."
@@ -87,7 +89,9 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
             # C:\tmp is a common, publicly writable directory.
             os.makedirs(r"C:\tmp", exist_ok=True)
             with open(r"C:\tmp\service_debug.log", "a") as f:
-                f.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - SVC({self._svc_name_}): {message}\n")
+                f.write(
+                    f"{time.strftime('%Y-%m-%d %H:%M:%S')} - SVC({self._svc_name_}): {message}\n"
+                )
         except Exception:
             # If even this fails, there's nothing more we can do.
             pass
@@ -104,17 +108,21 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
         """The main service entry point, containing all startup and running logic."""
         # --- Stage 1: Initial Setup (Pre-Logging) ---
         try:
-            if getattr(sys, 'frozen', False):
+            if getattr(sys, "frozen", False):
                 # If running as a frozen exe (e.g., PyInstaller)
                 script_dir = os.path.dirname(sys.executable)
             else:
                 # If running as a normal .py script
                 script_dir = os.path.dirname(os.path.realpath(__file__))
-            
+
             os.chdir(script_dir)
-            self.emergency_log(f"SvcDoRun started. Working directory set to: {script_dir}")
+            self.emergency_log(
+                f"SvcDoRun started. Working directory set to: {script_dir}"
+            )
         except Exception as e:
-            self.emergency_log(f"CRITICAL FAILURE: Could not set working directory. Error: {e}")
+            self.emergency_log(
+                f"CRITICAL FAILURE: Could not set working directory. Error: {e}"
+            )
             self.ReportServiceStatus(win32service.SERVICE_STOPPED)
             return
 
@@ -131,24 +139,29 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
             self.logger.info("BedrockServer instantiated successfully.")
 
             server_exe_path = self.server.bedrock_executable_path
-            pipe_name = PIPE_NAME_TEMPLATE.format(server_name=re.sub(r"\W+", "_", self.server.server_name))
+            pipe_name = PIPE_NAME_TEMPLATE.format(
+                server_name=re.sub(r"\W+", "_", self.server.server_name)
+            )
             output_file = self.server.server_log_path
             pid_file_path = self.server.get_pid_file_path()
             self.logger.info(f"Paths prepared. Executable: {server_exe_path}")
 
             self.logger.info("Attempting to start bedrock_server.exe with Popen.")
             os.makedirs(self.server.server_dir, exist_ok=True)
-            log_handle = open(output_file, 'ab')
+            log_handle = open(output_file, "ab")
             self.bedrock_process = subprocess.Popen(
                 [server_exe_path],
                 cwd=self.server.server_dir,
                 stdin=subprocess.PIPE,
                 stdout=log_handle,
                 stderr=subprocess.STDOUT,
-                text=False, bufsize=0,
-                creationflags=subprocess.CREATE_NO_WINDOW
+                text=False,
+                bufsize=0,
+                creationflags=subprocess.CREATE_NO_WINDOW,
             )
-            self.logger.info(f"bedrock_server.exe started with PID {self.bedrock_process.pid}.")
+            self.logger.info(
+                f"bedrock_server.exe started with PID {self.bedrock_process.pid}."
+            )
 
             self.logger.info("Writing PID file.")
             core_process.write_pid_to_file(pid_file_path, self.bedrock_process.pid)
@@ -156,8 +169,13 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
             self.logger.info("Starting pipe listener thread.")
             pipe_listener_thread = threading.Thread(
                 target=_main_pipe_server_listener_thread,
-                args=(pipe_name, self.bedrock_process, self.server_name, self.shutdown_event),
-                daemon=True
+                args=(
+                    pipe_name,
+                    self.bedrock_process,
+                    self.server_name,
+                    self.shutdown_event,
+                ),
+                daemon=True,
             )
             pipe_listener_thread.start()
 
@@ -173,7 +191,10 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
         except Exception as e:
             self.emergency_log(f"FATAL ERROR in SvcDoRun: {e}")
             if self.logger:
-                self.logger.error(f"FATAL ERROR in SvcDoRun for service '{self._svc_name_}': {e}", exc_info=True)
+                self.logger.error(
+                    f"FATAL ERROR in SvcDoRun for service '{self._svc_name_}': {e}",
+                    exc_info=True,
+                )
             self.SvcStop()
 
         finally:
@@ -183,20 +204,28 @@ class BedrockServerWindowsService(win32serviceutil.ServiceFramework):
                 self.logger.info("Entering service cleanup (finally block).")
 
             if self.bedrock_process and self.bedrock_process.poll() is None:
-                if self.logger: self.logger.info("Sending 'stop' command to Bedrock server.")
+                if self.logger:
+                    self.logger.info("Sending 'stop' command to Bedrock server.")
                 try:
-                    if self.bedrock_process.stdin and not self.bedrock_process.stdin.closed:
+                    if (
+                        self.bedrock_process.stdin
+                        and not self.bedrock_process.stdin.closed
+                    ):
                         self.bedrock_process.stdin.write(b"stop\r\n")
                         self.bedrock_process.stdin.flush()
                         self.bedrock_process.stdin.close()
                     self.bedrock_process.wait(timeout=20)
                 except Exception as e:
-                    if self.logger: self.logger.warning(f"Graceful stop failed: {e}. Terminating process.")
+                    if self.logger:
+                        self.logger.warning(
+                            f"Graceful stop failed: {e}. Terminating process."
+                        )
                     core_process.terminate_process_by_pid(self.bedrock_process.pid)
 
-            if hasattr(self, 'server'):
+            if hasattr(self, "server"):
                 core_process.remove_pid_file_if_exists(self.server.get_pid_file_path())
-            
+
             self.emergency_log("Cleanup complete. Reporting STOPPED.")
-            if self.logger: self.logger.info("Cleanup complete. Reporting STOPPED.")
+            if self.logger:
+                self.logger.info("Cleanup complete. Reporting STOPPED.")
             self.ReportServiceStatus(win32service.SERVICE_STOPPED)

--- a/src/bedrock_server_manager/logging.py
+++ b/src/bedrock_server_manager/logging.py
@@ -48,7 +48,7 @@ def setup_logging(
     Returns:
         The configured logger instance for "bedrock_server_manager".
     """
-    logger = logging.getLogger("bedrock_server_manager")
+    logger = logging.getLogger()
     logger.setLevel(file_log_level)  # Set the threshold for the logger
 
     # Prevent adding handlers multiple times if this function is called again


### PR DESCRIPTION
Windows service with one flaw, you must use the SC.exe command to start/stop the service bedrock-server_name

a BSM session cannot be opened with the bedrock-server-manager/python -m bedrock_server_manager command while any service using it is running, all BSM services must be stopped before you can use it again

services will not run if you have a BSM session already open, but multiple services can be started/stopped

sometimes you need a full reboot before a service can be started again?

after you create a service you need to go into the SC app and change the account type from local system to your windows user account