### PR TITLE
Test/add-coverage-report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ Changelog = "https://bedrock-server-manager.readthedocs.io/en/latest/changelog.h
 dev = [
     "pytest >=8.4.0,<9.1",
     "pytest-mock >=3.14.0,<3.16",
+    "pytest-cov >=6.0.0,<7.0",
     "httpx >=0.28.0,<0.29",
     "pytest-asyncio >=1.1.0,<1.4",
     "types-requests >=2.32.0,<2.34",
@@ -114,6 +115,24 @@ bedrock-server-manager = "bedrock_server_manager.__main__:main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+addopts = "--cov=bedrock_server_manager --cov-report=term --cov-report=html --cov-report=xml"
+
+[tool.coverage.run]
+source = ["src/bedrock_server_manager"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"


### PR DESCRIPTION
Use `pytest-cov` to generate HTML/XML/CLI report on test coverage for the python code