### PR TITLE
Fix/convert start server to background task

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -330,15 +330,21 @@ export async function sendServerActionRequest(
         `${functionName}: HTTP request successful (Status: ${response.status}). Checking application status in response...`,
       );
       // Check 'status' field within the JSON response data
-      if (responseData && responseData.status === "success") {
+      if (
+        responseData &&
+        (responseData.status === "success" || responseData.status === "pending")
+      ) {
         const successMsg =
           responseData.message || `Action at ${apiUrl} completed successfully.`;
         console.info(
-          `${functionName}: Application success. Message: "${successMsg}"`,
+          `${functionName}: Application success/pending. Message: "${successMsg}"`,
         );
         if (!suppressSuccessPopup) {
           // Only show popup if not suppressed
-          showStatusMessage(successMsg, "success");
+          // Use 'info' for pending, 'success' for success if distinction is needed
+          const msgType =
+            responseData.status === "pending" ? "info" : "success";
+          showStatusMessage(successMsg, msgType);
         }
         // Optionally trigger UI updates based on success here if needed
       } else if (responseData && responseData.status === "confirm_needed") {

--- a/src/bedrock_server_manager/plugins/default/autostart_plugin.py
+++ b/src/bedrock_server_manager/plugins/default/autostart_plugin.py
@@ -9,7 +9,7 @@ class AutostartServers(PluginBase):
     Starts all servers with the autostart setting set to true on manager startup.
     """
 
-    version = "1.0.0"
+    version = "1.0.1"
 
     def on_load(self):
         """
@@ -29,6 +29,12 @@ class AutostartServers(PluginBase):
 
             if server_settings:
                 self.logger.info(
-                    f"Server '{server_name}' has autostart enabled, starting it now."
+                    f"Server '{server_name}' has autostart enabled, starting it now (background task)."
                 )
-                self.api.start_server(server_name)
+                # Use the task manager to start the server in the background so app startup isn't blocked
+                # especially if an update is required.
+                self.api.app_context.task_manager.run_task(
+                    self.api.start_server,
+                    server_name=server_name,
+                    username="System (Autostart)",
+                )

--- a/src/bedrock_server_manager/web/routers/server_actions.py
+++ b/src/bedrock_server_manager/web/routers/server_actions.py
@@ -49,7 +49,7 @@ class CommandPayload(BaseModel):
 @router.post(
     "/api/server/{server_name}/start",
     response_model=ActionResponse,
-    status_code=status.HTTP_200_OK,
+    status_code=status.HTTP_202_ACCEPTED,
     summary="Start a server instance",
     tags=["Server Actions API"],
 )
@@ -59,28 +59,25 @@ async def start_server_route(
     app_context: AppContext = Depends(get_app_context),
 ):
     """
-    Starts a specific Bedrock server instance.
+    Initiates starting a specific Bedrock server instance in the background.
+
+    The server start operation is performed as a background task.
+    This endpoint immediately returns a 202 Accepted response.
     """
     identity = current_user.username
     logger.info(f"API: Start server request for '{server_name}' by user '{identity}'.")
+    task_id = app_context.task_manager.run_task(
+        server_api.start_server,
+        username=current_user.username,
+        server_name=server_name,
+        app_context=app_context,
+    )
 
-    try:
-        result = server_api.start_server(
-            server_name=server_name, app_context=app_context
-        )
-        if result.get("status") == "success":
-            return ActionResponse(
-                message=result.get("message") or "Server started successfully"
-            )
-        else:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.get("message"),
-            )
-    except BSMError as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        )
+    return ActionResponse(
+        status="pending",
+        message=f"Start operation for server '{server_name}' initiated in background.",
+        task_id=task_id,
+    )
 
 
 @router.post(

--- a/tests/web/routers/test_server_actions_router.py
+++ b/tests/web/routers/test_server_actions_router.py
@@ -8,8 +8,9 @@ def test_start_server_route(authenticated_client, real_bedrock_server):
     response = authenticated_client.post(
         f"/api/server/{real_bedrock_server.server_name}/start"
     )
-    assert response.status_code == 200
-    assert response.json()["status"] == "success"
+    assert response.status_code == 202
+    assert response.json()["status"] == "pending"
+    assert "initiated in background" in response.json()["message"]
 
 
 def test_stop_server_route(authenticated_client, real_bedrock_server):


### PR DESCRIPTION
Converts the start server API route to a background tasks to prevent the web server from freezing until the update is done